### PR TITLE
Fixing synccompress

### DIFF
--- a/pipeline/packager.py
+++ b/pipeline/packager.py
@@ -1,4 +1,5 @@
 import os
+import os.path
 import urlparse
 
 from pipeline.conf import settings
@@ -49,7 +50,7 @@ class Packager(object):
         return self.compiler.compile(paths)
 
     def pack(self, package, compress, signal, **kwargs):
-        if settings.PIPELINE_AUTO or self.force:
+        if settings.PIPELINE_AUTO or self.force or not os.path.exists(package['output']):
             need_update, version = self.versioning.need_update(
                 package['output'], package['paths'])
             if need_update or self.force:


### PR DESCRIPTION
I think this code should correctly fix synccompress without breaking the compress tag.

However, I think that it results in files getting automatically generated at run time even if PIPELINE_AUTO is False, which I think probably misses the point (although, if PIPELINE_AUTO is False, and the file doesn't exist, then the end user's going to be unhappy anyway, so maybe this is a sensible "catch all"?)
