### PR TITLE
Fixes things on Linux. 

### DIFF
--- a/pipeline/compilers/less/__init__.py
+++ b/pipeline/compilers/less/__init__.py
@@ -17,10 +17,9 @@ class LessCompiler(SubProcessCompiler):
         in_file.write(content)
         in_file.flush()
 
-        command = '%s %s %s' % (
+        command = '%s %s' % (
             settings.PIPELINE_LESS_BINARY,
-            in_filename,
-            settings.PIPELINE_LESS_ARGUMENTS
+            in_filename
         )
         content = self.execute_command(command, content)
 


### PR DESCRIPTION
Fix for issue #20. `lessc` fails on Linux when invoked with parameters. 
