### PR TITLE
Google closure compiler doesn't have --verbose.  This means that it simpl

### DIFF
--- a/pipeline/compressors/closure/__init__.py
+++ b/pipeline/compressors/closure/__init__.py
@@ -5,6 +5,4 @@ from pipeline.compressors import SubProcessCompressor
 class ClosureCompressor(SubProcessCompressor):
     def compress_js(self, js):
         command = '%s %s' % (settings.PIPELINE_CLOSURE_BINARY, settings.PIPELINE_CLOSURE_ARGUMENTS)
-        if self.verbose:
-            command += ' --verbose'
         return self.execute_command(command, js)


### PR DESCRIPTION
Google closure compiler doesn't have --verbose.  This means that it simply prints "--verbose" is not a valid option and doesn't write the result to standard out.
