### PR TITLE
Don't attempt to compress CSS or JS if the compressor class is empty.

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -174,6 +174,8 @@ Other settings
 ............................
 
   Compressor class to be applied to CSS files.
+
+  If empty or ``None``, CSS files won't be compressed.
   
   Defaults to ``'pipeline.compressors.yui.YUICompressor'``.
 
@@ -181,6 +183,8 @@ Other settings
 ...........................
 
   Compressor class to be applied to JavaScript files.
+
+  If empty or ``None``, JavaScript files won't be compressed.
   
   Defaults to ``'pipeline.compressors.yui.YUICompressor'``
 

--- a/pipeline/compressors/__init__.py
+++ b/pipeline/compressors/__init__.py
@@ -52,13 +52,20 @@ class Compressor(object):
         if templates:
             js = js + self.compile_templates(templates)
         js = "(function() { %s }).call(this);" % js
-        js = getattr(self.js_compressor(verbose=self.verbose), 'compress_js')(js)
+
+        compressor = self.js_compressor
+        if compressor:
+            js = getattr(compressor(verbose=self.verbose), 'compress_js')(js)
+
         return js
 
     def compress_css(self, paths, variant=None, asset_url=None, **kwargs):
         """Concatenate and compress CSS files"""
         css = self.concatenate_and_rewrite(paths, variant)
-        css = getattr(self.css_compressor(verbose=self.verbose), 'compress_css')(css)
+
+        compressor = self.css_compressor
+        if compressor:
+            css = getattr(compressor(verbose=self.verbose), 'compress_css')(css)
         if not variant:
             return css
         elif variant == "datauri":

--- a/pipeline/utils.py
+++ b/pipeline/utils.py
@@ -5,6 +5,9 @@ from django.utils import importlib
 
 
 def to_class(class_str):
+    if not class_str:
+        return None
+
     module_bits = class_str.split('.')
     module_path, class_name = '.'.join(module_bits[:-1]), module_bits[-1]
     module = importlib.import_module(module_path)


### PR DESCRIPTION
The CSS and JS compressors can be turned off individually by specifying
either None or an empty string as the value for either
PIPELINE_CSS_COMPRESSOR or PIPELINE_JS_COMPRESSOR.

This is useful when you want to conditionally disable a compressor based
on what's available locally, or when a byproduct of a compiler is to
compress the content.
