### PR TITLE
Support disabling asset path normalization in CSS.

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -100,6 +100,16 @@ Group options
   For CSS, if you do not specify ``extra_context``/``media``, the default media in
   the ``<link>`` output will be ``media="all"``.
 
+``absolute_asset_paths``
+........................
+
+  **Optional**
+
+  Indicates if relative paths in CSS files should be made absolute, based on
+  ``PIPELINE_URL``. This only applies to entries in ``PIPELINE_CSS``.
+
+  Defaults to ``True``.
+
 .. note::
 
   Note that all filenames are specified relative to ``PIPELINE_ROOT``, and thus the source
@@ -253,7 +263,8 @@ Rewriting CSS urls
 ==================
 
 If source CSS contain a relative URL (i.e. relative to current file),
-those URL will be converted to full relative path using ``PIPELINE_URL``.
+and ``absolute_asset_paths`` is set to ``True`` or left out in the package
+entry, the URL will be converted to full relative path using ``PIPELINE_URL``.
 This conversion is performed before any compressors are applied ::
 
   media/js/fancybox/

--- a/pipeline/compressors/__init__.py
+++ b/pipeline/compressors/__init__.py
@@ -55,9 +55,11 @@ class Compressor(object):
         js = getattr(self.js_compressor(verbose=self.verbose), 'compress_js')(js)
         return js
 
-    def compress_css(self, paths, variant=None, asset_url=None, **kwargs):
+    def compress_css(self, paths, variant=None, asset_url=None,
+                     absolute_asset_paths=True, **kwargs):
         """Concatenate and compress CSS files"""
-        css = self.concatenate_and_rewrite(paths, variant)
+        css = self.concatenate_and_rewrite(paths, variant,
+                                           absolute_asset_paths)
         css = getattr(self.css_compressor(verbose=self.verbose), 'compress_css')(css)
         if not variant:
             return css
@@ -101,7 +103,8 @@ class Compressor(object):
         ), r"\1", path)
         return re.sub(r"[\/\\]", "_", name)
 
-    def concatenate_and_rewrite(self, paths, variant=None):
+    def concatenate_and_rewrite(self, paths, variant=None,
+                                absolute_asset_paths=True):
         """Concatenate together files and rewrite urls"""
         stylesheets = []
         for path in paths:
@@ -109,7 +112,8 @@ class Compressor(object):
                 asset_path = match.group(1)
                 if asset_path.startswith("http") or asset_path.startswith("//"):
                     return "url(%s)" % asset_path
-                asset_url = self.construct_asset_path(asset_path, path, variant)
+                asset_url = self.construct_asset_path(asset_path, path, variant,
+                                                      absolute_asset_paths)
                 return "url(%s)" % asset_url
             content = self.read_file(path)
             content = re.sub(URL_DETECTOR, reconstruct, content)
@@ -120,11 +124,14 @@ class Compressor(object):
         """Concatenate together a list of files"""
         return '\n'.join([self.read_file(path) for path in paths])
 
-    def construct_asset_path(self, asset_path, css_path, variant=None):
+    def construct_asset_path(self, asset_path, css_path, variant=None,
+                             absolute_asset_paths=True):
         """Return a rewritten asset URL for a stylesheet"""
         public_path = self.absolute_path(asset_path, os.path.dirname(css_path))
         if self.embeddable(public_path, variant):
             return "__EMBED__%s" % public_path
+        if not absolute_asset_paths:
+            return asset_path
         if not os.path.isabs(asset_path):
             asset_path = self.relative_path(public_path)
         return settings.PIPELINE_URL + asset_path[1:]

--- a/pipeline/packager.py
+++ b/pipeline/packager.py
@@ -43,8 +43,10 @@ class Packager(object):
 
     def pack_stylesheets(self, package, **kwargs):
         variant = package.get('variant', None)
+        absolute_asset_paths = package.get('absolute_asset_paths', True)
         return self.pack(package, self.compressor.compress_css, css_compressed,
-            variant=variant, **kwargs)
+            variant=variant, absolute_asset_paths=absolute_asset_paths,
+            **kwargs)
 
     def compile(self, paths):
         return self.compiler.compile(paths)
@@ -100,6 +102,9 @@ class Packager(object):
             packages[name]['output'] = config[name]['output_filename']
             packages[name]['context'] = {}
             packages[name]['manifest'] = True
+            if 'absolute_asset_paths' in config[name]:
+                packages[name]['absolute_asset_paths'] = \
+                    config[name]['absolute_asset_paths']
             if 'extra_context' in config[name]:
                 packages[name]['context'] = config[name]['extra_context']
             if 'template_name' in config[name]:

--- a/tests/tests/compressor.py
+++ b/tests/tests/compressor.py
@@ -88,6 +88,15 @@ class CompressorTest(TestCase):
             "css/plugins/gallery.css")
         self.assertEquals(asset_path, "http://localhost/static/images/sprite.png")
 
+        asset_path = self.compressor.construct_asset_path("../../images/sprite.png",
+            "css/plugins/gallery.css",
+            absolute_asset_paths=False)
+        self.assertEquals(asset_path, "../../images/sprite.png")
+        asset_path = self.compressor.construct_asset_path("/images/sprite.png",
+            "css/plugins/gallery.css",
+            absolute_asset_paths=False)
+        self.assertEquals(asset_path, "/images/sprite.png")
+
     def test_url_rewrite(self):
         self.maxDiff = None
         output = self.compressor.concatenate_and_rewrite([


### PR DESCRIPTION
This introduces an option in PIPELINE_CSS package rules for turning off
the feature to make relative paths absolute. In certain deployments,
relative paths are important and need to be preserved.

Packages can now set absolute_asset_paths to False to turn off this
functionality.
