### PR TITLE
Respect PIPELINE_AUTO when choosing to compile packages in templatetags.

### DIFF
--- a/pipeline/templatetags/compressed.py
+++ b/pipeline/templatetags/compressed.py
@@ -26,9 +26,10 @@ class CompressedCSSNode(template.Node):
         if settings.PIPELINE:
             compressed_path = self.packager.pack_stylesheets(package)
             return self.render_css(package, compressed_path)
-        else:
+        elif settings.PIPELINE_AUTO:
             package['paths'] = self.packager.compile(package['paths'])
-            return self.render_individual(package)
+
+        return self.render_individual(package)
 
     def render_css(self, package, path):
         context = {}
@@ -68,10 +69,11 @@ class CompressedJSNode(template.Node):
         if settings.PIPELINE:
             compressed_path = self.packager.pack_javascripts(package)
             return self.render_js(package, compressed_path)
-        else:
+        elif settings.PIPELINE_AUTO:
             package['paths'] = self.packager.compile(package['paths'])
-            templates = self.packager.pack_templates(package)
-            return self.render_individual(package, templates)
+
+        templates = self.packager.pack_templates(package)
+        return self.render_individual(package, templates)
 
     def render_js(self, package, path):
         context = {}


### PR DESCRIPTION
The documentation states that if PIPELINE_AUTO is off, we won't process
stylesheets and scripts. However, this isn't the case in practice. The
files are still run through a compiler, resulting in new files being
output rather than the originals.

This becomes a problem when trying to use, say, .less files with the
in-browser lessCSS runtime.

The templatetags now respect PIPELINE_AUTO and won't pass anything
through the compilers. This may break some uses, but it adheres to the
documentation and prevents unexpected files when pipelining is turned
off.
