### PR TITLE
Pipeline produces URLs with backslashes on Windows.

### DIFF
--- a/pipeline/compressors/__init__.py
+++ b/pipeline/compressors/__init__.py
@@ -142,7 +142,8 @@ class Compressor(object):
             return "__EMBED__%s" % public_path
         if not os.path.isabs(asset_path):
             asset_path = self.relative_path(public_path)
-        return settings.PIPELINE_URL + asset_path[1:]
+        asset_url = asset_path.replace(os.sep, '/')
+        return settings.PIPELINE_URL + asset_url[1:]
 
     def embeddable(self, path, variant):
         """Is the asset embeddable ?"""

--- a/pipeline/packager.py
+++ b/pipeline/packager.py
@@ -38,8 +38,10 @@ class Packager(object):
             )
 
     def individual_url(self, filename):
+        relative_path = self.compressor.relative_path(filename)[1:]
+        relative_url = relative_path.replace(os.sep, '/')
         return urlparse.urljoin(settings.PIPELINE_URL,
-            self.compressor.relative_path(filename)[1:])
+            relative_url)
 
     def pack_stylesheets(self, package, **kwargs):
         variant = package.get('variant', None)


### PR DESCRIPTION
Pipeline running on Windows produces URLs like this:

> /pipeline_url\css\mycss.css

The problem is in the file packager.py, method Packager.relative_path:

``` python
    def relative_path(self, absolute_path):
        """Rewrite paths relative to the output stylesheet path"""
        absolute_path = self.absolute_path(absolute_path, settings.PIPELINE_ROOT)
        return os.path.join(os.sep, relpath(absolute_path, settings.PIPELINE_ROOT))
```

This function first translates whatever file path (e.g. "css/mycss.css") into an absolute path, which on Windows contains backslashes. Then the relative path is calculated, which still contains backslashes. The result of this function is used directly in URLs (e.g. by the method individual_url) without converting backslashes into forward slashes.
