### PR TITLE
Fixing an issue when for files which contain unicode data

### DIFF
--- a/pipeline/packager.py
+++ b/pipeline/packager.py
@@ -2,6 +2,7 @@ import os
 import urlparse
 
 from django.core.files.base import ContentFile
+from django.utils.encoding import smart_str
 
 from pipeline.conf import settings
 from pipeline.compilers import Compiler
@@ -85,7 +86,7 @@ class Packager(object):
         return self.compressor.compile_templates(package['templates'])
 
     def save_file(self, path, content):
-        return storage.save(path, ContentFile(content))
+        return storage.save(path, ContentFile(smart_str(content)))
 
     def create_packages(self, config):
         packages = {}


### PR DESCRIPTION
The django.core.files.base module uses the cStringIO package where available. However, unlike StringIO, cStringIO does not support unicode data, and the result is additional null bytes being entered into the output file.

The trick seems to be to convert the data into a byte string before passing it into ContentFile, which I do here using Django's smart_str() utility.
