### PR TITLE
add support to output uncompiled .less css file

### DIFF
--- a/pipeline/templates/pipeline/css.html
+++ b/pipeline/templates/pipeline/css.html
@@ -1,1 +1,1 @@
-<link href="{{ url }}" rel="stylesheet" type="text/css"{% if media %} media="{{ media }}"{% endif %}{% if title %} title="{{ title|default:"all" }}"{% endif %}{% if charset %} charset="{{ charset }}"{% endif %} />
+<link href="{{ url }}" rel="{{ rel|default:"stylesheet" }}" type="text/css"{% if media %} media="{{ media }}"{% endif %}{% if title %} title="{{ title|default:"all" }}"{% endif %}{% if charset %} charset="{{ charset }}"{% endif %} />

--- a/pipeline/templatetags/compressed.py
+++ b/pipeline/templatetags/compressed.py
@@ -36,9 +36,14 @@ class CompressedCSSNode(template.Node):
             package['template'] = "pipeline/css.html"
         if 'context' in package:
             context = package['context']
+        url = self.packager.individual_url(path)
         context.update({
-            'url': self.packager.individual_url(path)
+            'url': url
         })
+        if url.endswith('.less'):
+            context.update({
+                'rel': 'stylesheet/less'
+            })
         return render_to_string(package['template'], context)
 
     def render_individual(self, package):


### PR DESCRIPTION
it's preferable to use less.js to load .less css files dynamically on a development site.

if PIPELINE is set to True, .less files are compiled and compressed the way you want.
if PIPELINE is False, .less files are output with in a link tag with rel='stylesheet/less'.
so less.js can recognize them.

this can't be done by modifying the less compiler class, since the compiler is not called when PIPELINE is set to False.

to use this feature. one should configure pipeline such that,

**in django's settings.py**

``` python
PIPELINE = not DEBUG

## don't compile .less file if PIPELINE is false
PIPELINE_COMPILERS = None if not PIPELINE else (
    'pipeline.compilers.less.LessCompiler',
)

## put you .less files into the 'source_filenames' tuple as usual
#PIPELINE_CSS = { ... }

## use a list to hold you js 'source_filenames'
PIPELINE_JS_SOURCES = [
    'vendors/jquery/jquery-1.6.1.min.js',
    'path/of/your/script.js'
]

## add less.js to the list if PIPELINE is false
if not PIPELINE:
    PIPELINE_JS_SOURCES.insert(0, 'vendors/lesscss/less-1.1.5.min.js')
## or
    PIPELINE_JS_SOURCES.append('vendors/lesscss/less-1.1.5.min.js')

## convert to tuple when used in PIPELINE_JS
PIPELINE_JS = {
    'all': {
        'source_filenames': tuple(PIPELINE_JS_SOURCES),
        'output_filename': 'js/script.r?.js',
    },
}
```
