### PR TITLE
stop reading PIPELINE_ROOT and PIPELINE_URL settings from MEDIA_*

### DIFF
--- a/pipeline/conf/settings.py
+++ b/pipeline/conf/settings.py
@@ -2,9 +2,6 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
 
-PIPELINE_ROOT = getattr(settings, 'PIPELINE_ROOT', settings.MEDIA_ROOT)
-PIPELINE_URL = getattr(settings, 'PIPELINE_URL', settings.MEDIA_URL)
-
 PIPELINE = getattr(settings, 'PIPELINE', not settings.DEBUG)
 PIPELINE_ROOT = getattr(settings, 'PIPELINE_ROOT', settings.STATIC_ROOT)
 PIPELINE_URL = getattr(settings, 'PIPELINE_URL', settings.STATIC_URL)


### PR DESCRIPTION
see ticket #10650 of the django project. https://code.djangoproject.com/ticket/10650
MEDIA_\* settings is for user-uploaded files. 
there's no point that pipeline should read this directory.
and the same with PIPELINE_URL.
