### PR TITLE
cssmin compressor+doc; fixed sample compressor

### DIFF
--- a/docs/compressors.rst
+++ b/docs/compressors.rst
@@ -142,6 +142,18 @@ To us it for your stylesheets add this to your ``PIPELINE_CSS_COMPRESSOR`` ::
 
   Default to ``'--template=highest'``
 
+cssmin compressor
+=================
+
+The cssmin compressor uses the `cssmin <http://pypi.python.org/pypi/cssmin/>`_
+Python library to compress stylesheets. To use it, specify this
+``PIPELINE_CSS_COMPRESSOR`` ::
+
+  PIPELINE_CSS_COMPRESSOR = 'pipeline.compressors.cssmin.CssminCompressor'
+
+Install the cssmin library with your favorite Python package manager. E.g. ::
+
+  pip install cssmin
 
 Write your own compressor class
 ===============================

--- a/pipeline/compressors/cssmin/__init__.py
+++ b/pipeline/compressors/cssmin/__init__.py
@@ -1,0 +1,13 @@
+from pipeline.compressors import CompressorBase
+
+
+class CssminCompressor(CompressorBase):
+    """
+    CSS compressor based on the Python library cssmin
+    (http://pypi.python.org/pypi/cssmin/).
+
+    """
+
+    def compress_css(self, css):
+        from cssmin import cssmin
+        return cssmin(css)


### PR DESCRIPTION
cssmin is a python lib, and so requires no external executable. (If only there were a python less compiler :)) Also fixed a typo on the example custom compressor in the doc.
