### PR TITLE
Support for Less in Development Mode

### DIFF
--- a/pipeline/templates/pipeline/css.html
+++ b/pipeline/templates/pipeline/css.html
@@ -1,1 +1,1 @@
-<link href="{{ url }}" rel="stylesheet" type="text/css"{% if media %} media="{{ media }}"{% endif %}{% if title %} title="{{ title|default:"all" }}"{% endif %}{% if charset %} charset="{{ charset }}"{% endif %} />
+<link href="{{ url }}" {% if rel and rel == 'less' %}rel="stylesheet/less"{% else %}rel='stylesheet'{% endif %} type="text/css"{% if media %} media="{{ media }}"{% endif %}{% if title %} title="{{ title|default:"all" }}"{% endif %}{% if charset %} charset="{{ charset }}"{% endif %} />

--- a/pipeline/templatetags/compressed.py
+++ b/pipeline/templatetags/compressed.py
@@ -40,6 +40,8 @@ class CompressedCSSNode(template.Node):
         context.update({
             'url': staticfiles_storage.url(path)
         })
+        if staticfiles_storage.url(path).endswith('.less'):
+            context.update({'rel' : 'less'})
         return render_to_string(template_name, context)
 
     def render_individual(self, package, paths):


### PR DESCRIPTION
While in a development style setup, I don't want myself or others to necessarily have to rely on having a lessc binary installed in order to work on the project.  Given this, I have updated the templatetag to check if the particular CSS file being inserted ends in '.less' and if so, changes the rel='' to the appropriate rel="stylesheet/less" for use with the less.js method.
