### PR TITLE
Fixed an import error in cssmin compressor.

### DIFF
--- a/pipeline/compressors/cssmin.py
+++ b/pipeline/compressors/cssmin.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from pipeline.compressors import CompressorBase
 
 


### PR DESCRIPTION
Without this patch, I'm getting this error when I run `bin/python manage.py collectstatic --noinput`.

``` python
  File "/home/berkerpeksag/hacking/berkerpeksag/lib/python2.7/site-packages/pipeline/packager.py", line 100, in pack
    content = compress(paths, **kwargs)
  File "/home/berkerpeksag/hacking/berkerpeksag/lib/python2.7/site-packages/pipeline/compressors/__init__.py", line 78, in compress_css
    css = getattr(compressor(verbose=self.verbose), 'compress_css')(css)
  File "/home/berkerpeksag/hacking/berkerpeksag/lib/python2.7/site-packages/pipeline/compressors/cssmin.py", line 11, in compress_css
    from cssmin import cssmin
ImportError: cannot import name cssmin
```

For more information: http://www.python.org/dev/peps/pep-0328/
http://docs.python.org/whatsnew/2.5.html#pep-328-absolute-and-relative-imports
