### PR TITLE
fix #107 -- rather than deleting newlines in javascript template strings, escape them

### DIFF
--- a/pipeline/compressors/__init__.py
+++ b/pipeline/compressors/__init__.py
@@ -91,7 +91,7 @@ class Compressor(object):
         base_path = self.base_path(paths)
         for path in paths:
             contents = self.read_file(path)
-            contents = re.sub(r"\r?\n", "", contents)
+            contents = re.sub(r"\r?\n", "\\\\n", contents)
             contents = re.sub(r"'", "\\'", contents)
             name = self.template_name(path, base_path)
             compiled += "%s['%s'] = %s('%s');\n" % (


### PR DESCRIPTION
See issue #107 for an explanation of the problem I'm trying to fix.

Probably newlines were originally deleted because of the notion that "newlines are not significant in HTML". That may be close to true but unfortunately it is not exactly true :) , and I hope you guys agree this approach will cause minimum surprise for new users like me.

I think it's also important to do minimum modifications on template strings because you don't know what template language the user may be working with.

Thanks, I'm enjoying working with django-pipeline!
