### PR TITLE
Storage settings documentation fix

### DIFF
--- a/docs/storages.rst
+++ b/docs/storages.rst
@@ -30,7 +30,7 @@ And if you want versioning use ::
 Pipeline is also providing a storage that play nicely with staticfiles app
 particularly for development : ::
 
-  PIPELINE_STORAGE = 'pipeline.storage.PipelineFinderStorage'
+  STATICFILES_STORAGE = 'pipeline.storage.PipelineFinderStorage'
 
 
 Using with other storages


### PR DESCRIPTION
I assume that `pipeline.storage.PipelineFinderStorage` should be assigned to `STATICFILES_STORAGE` rather than to `PIPELINE_STORAGE`. (It doesn't work otherwise)
