### PR TITLE
Fix an IOError

### DIFF
--- a/pipeline/compilers/__init__.py
+++ b/pipeline/compilers/__init__.py
@@ -30,7 +30,11 @@ class Compiler(object):
                     try:
                         infile = finders.find(input_path)
                         outfile = finders.find(output_path)
-                        outdated = self.is_outdated(input_path, output_path)
+                        if outfile is None:
+                            outfile = self.output_path(infile, compiler.output_extension)
+                            outdated = False
+                        else:
+                            outdated = self.is_outdated(input_path, output_path)
                         compiler.compile_file(infile, outfile, outdated=outdated, force=force)
                     except CompilerError:
                         if not self.storage.exists(output_path) or not settings.PIPELINE:


### PR DESCRIPTION
When you try to compile a new file, since the output file doesn't exists, _finders.find_ will return _None_ as output file name, instead of filename.ext. Which will lead to an _IOError_.

For example, if i try to compile a new file named _style.less_, the parsing will be outputted into the file _None_, and the script will fail to open _style.css_.
