### PR TITLE
Add on-the-fly minification

### DIFF
--- a/pipeline/compressors/__init__.py
+++ b/pipeline/compressors/__init__.py
@@ -67,6 +67,20 @@ class Compressor(object):
 
         return js
 
+    def compress_js_block(self, block, **kwargs):
+        """compress JS block"""
+        if not settings.PIPELINE_DISABLE_WRAPPER:
+            content = "(function() { %s }).call(this);" % block
+        else:
+            content = block
+
+        compressor = self.js_compressor
+        if compressor:
+            content = getattr(compressor(verbose=self.verbose),
+                              'compress_js')(content)
+
+        return content
+
     def compress_css(self, paths, output_filename, variant=None, **kwargs):
         """Concatenate and compress CSS files"""
         css = self.concatenate_and_rewrite(paths, output_filename, variant)
@@ -79,6 +93,15 @@ class Compressor(object):
             return self.with_data_uri(css)
         else:
             raise CompressorError("\"%s\" is not a valid variant" % variant)
+
+    def compress_css_block(self, block, **kwargs):
+        """compress CSS block"""
+        compressor = self.css_compressor
+        if compressor:
+            content = getattr(compressor(verbose=self.verbose),
+                              'compress_css')(block)
+
+        return content
 
     def compile_templates(self, paths):
         compiled = ""
@@ -154,7 +177,7 @@ class Compressor(object):
         """Is the asset embeddable ?"""
         name, ext = os.path.splitext(path)
         font = ext in FONT_EXTS
-        
+
         if not variant:
             return False
         if not (re.search(settings.PIPELINE_EMBED_PATH, path) and self.storage.exists(path)):

--- a/pipeline/templates/pipeline/inline_css.html
+++ b/pipeline/templates/pipeline/inline_css.html
@@ -1,0 +1,3 @@
+<style type="text/css" media="all">
+  {{ source|safe }}
+</style>


### PR DESCRIPTION
This commit add the possibility to minify css/js scripts on the fly. It can be useful when some scripts are dynamically generated by an application, and are therefore not stored in a file.
The code is quiet simple (but maybe there's a better way to do it), I choose not to handle the compilation (less, …) because the process is IMO way to heavy (it will need a cache system or something).
