### PR TITLE
provide required argument

### DIFF
--- a/pipeline/manifest.py
+++ b/pipeline/manifest.py
@@ -29,6 +29,8 @@ class PipelineManifest(Manifest):
         return packages
 
     def cache(self):
+        ignore_patterns = getattr(settings, "STATICFILES_IGNORE_PATTERNS", None)
+        
         if settings.PIPELINE:
             for package in self.packages:
                 yield str(self.packager.individual_url(package.output_filename))
@@ -36,5 +38,5 @@ class PipelineManifest(Manifest):
             for package in self.packages:
                 for path in self.packager.compile(package.paths):
                     yield str(self.packager.individual_url(path))
-        for path in self.finder.list():
+        for path in self.finder.list(ignore_patterns):
             yield str(self.packager.individual_url(path))


### PR DESCRIPTION
```
class BaseStorageFinder(BaseFinder):

    ...

    def list(self, ignore_patterns):
        
       ....
```

this class is present (and identical with regards to the list method) in both : 

```
staticfiles/finders.py @215
django/contrib/staticfiles/finders.py @206
```

Some kind of argument needs to be provided. this change prevents a yellow error screen.
