### PR TITLE
Allow compilers to compile relative to PIPELINE_ROOT.

### DIFF
--- a/pipeline/compilers/__init__.py
+++ b/pipeline/compilers/__init__.py
@@ -31,8 +31,12 @@ class Compiler(object):
                     output_path = self.output_path(input_path, compiler.output_extension)
                     paths[index] = output_path
                     try:
-                        infile = finders.find(input_path)
-                        outfile = finders.find(output_path)
+                        if settings.PIPELINE_ROOT_COMPILE:
+                            infile = os.path.join(settings.PIPELINE_ROOT, input_path)
+                            outfile = None
+                        else:
+                            infile = finders.find(input_path)
+                            outfile = finders.find(output_path)
                         if outfile is None:
                             outfile = self.output_path(infile, compiler.output_extension)
                             outdated = True
@@ -42,6 +46,7 @@ class Compiler(object):
                     except CompilerError:
                         if not self.storage.exists(output_path) or not settings.PIPELINE:
                             raise
+
         return paths
 
     def output_path(self, path, extension):

--- a/pipeline/conf/settings.py
+++ b/pipeline/conf/settings.py
@@ -4,6 +4,8 @@ PIPELINE = getattr(settings, 'PIPELINE', not settings.DEBUG)
 PIPELINE_ROOT = getattr(settings, 'PIPELINE_ROOT', settings.STATIC_ROOT)
 PIPELINE_URL = getattr(settings, 'PIPELINE_URL', settings.STATIC_URL)
 
+PIPELINE_ROOT_COMPILE = getattr(settings, 'PIPELINE_ROOT_COMPILE', False)
+
 PIPELINE_STORAGE = getattr(settings, 'PIPELINE_STORAGE',
     'pipeline.storage.PipelineFinderStorage')
 


### PR DESCRIPTION
As discussed in #112, this allows less to compile files that may be imported from other apps.

Setting PIPELINE_ROOT_COMPILE=True forces pipeline to compile relative to PIPELINE_ROOT.

This should not affect anyone and I suggest that it be made the default behaviour in the future.
