### PR TITLE
Add -p argument to the CoffeeScript compiler

### DIFF
--- a/pipeline/compilers/coffee.py
+++ b/pipeline/compilers/coffee.py
@@ -11,7 +11,7 @@ class CoffeeScriptCompiler(SubProcessCompiler):
     def compile_file(self, infile, outfile, outdated=False, force=False):
         if not outdated and not force:
             return  # File doesn't need to be recompiled
-        command = "%s -c %s %s > %s" % (
+        command = "%s -cp %s %s > %s" % (
             settings.PIPELINE_COFFEE_SCRIPT_BINARY,
             settings.PIPELINE_COFFEE_SCRIPT_ARGUMENTS,
             infile,


### PR DESCRIPTION
This is because CoffeeScript's compiler also tries to write the the script output itself to the file, causing the output file result to be (similar to)

```
EBUSY, open '/path/to/source/file/file.js'
```

instead of the actual file contents. `-p` suppresses this and causes it to print it to `stdout` (which django-pipeline then redirects as usual) instead.
