### PR TITLE
Update pipeline/manifest.py

### DIFF
--- a/pipeline/manifest.py
+++ b/pipeline/manifest.py
@@ -39,4 +39,6 @@ class PipelineManifest(Manifest):
                 for path in self.packager.compile(package.paths):
                     yield str(self.packager.individual_url(path))
         for path in self.finder.list(ignore_patterns):
+            if type(path) in (list, tuple): 
+                path = path[0]
             yield str(self.packager.individual_url(path))


### PR DESCRIPTION
Use correct path from ignored finder, since it seems to return a 
tuple containing the url and the storage object responsible for it.

we actually only want the file path.
 
