### PR TITLE
Ensure files import in less/stylus and other works

### DIFF
--- a/pipeline/compilers/__init__.py
+++ b/pipeline/compilers/__init__.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 
 import os
 
-from django.contrib.staticfiles import finders
 from django.core.files.base import ContentFile
 from django.utils.encoding import smart_str, smart_bytes
 
@@ -27,7 +26,7 @@ class Compiler(object):
                 compiler = compiler(verbose=self.verbose, storage=self.storage)
                 if compiler.match_file(input_path):
                     output_path = self.output_path(input_path, compiler.output_extension)
-                    infile = finders.find(input_path)
+                    infile = self.storage.path(input_path)
                     outfile = self.output_path(infile, compiler.output_extension)
                     outdated = compiler.is_outdated(input_path, output_path)
                     try:

--- a/pipeline/compressors/__init__.py
+++ b/pipeline/compressors/__init__.py
@@ -191,7 +191,7 @@ class Compressor(object):
         given the path of the stylesheet that contains it.
         """
         if posixpath.isabs(path):
-            path = posixpath.join(default_storage.location, path)
+            path = posixpath.join(self.storage.location, path)
         else:
             path = posixpath.join(start, path)
         return posixpath.normpath(path)
@@ -204,7 +204,7 @@ class Compressor(object):
 
     def read_bytes(self, path):
         """Read file content in binary mode"""
-        file = default_storage.open(path)
+        file = self.storage.open(path)
         content = file.read()
         file.close()
         return content

--- a/pipeline/packager.py
+++ b/pipeline/packager.py
@@ -65,7 +65,7 @@ class Packager(object):
         self.storage = storage
         self.verbose = verbose
         self.compressor = Compressor(storage=storage, verbose=verbose)
-        self.compiler = Compiler(verbose=verbose)
+        self.compiler = Compiler(storage=storage, verbose=verbose)
         if css_packages is None:
             css_packages = settings.PIPELINE_CSS
         if js_packages is None:


### PR DESCRIPTION
Ensure files import in less/stylus and other works when files are across static directories, see #112.
