### PR TITLE
Fixed SyntaxError syntax raised by TemplateSyntaxError.

### DIFF
--- a/pipeline/templatetags/compressed.py
+++ b/pipeline/templatetags/compressed.py
@@ -98,7 +98,7 @@ def compressed_css(parser, token):
     try:
         tag_name, name = token.split_contents()
     except ValueError:
-        raise template.TemplateSyntaxError, '%r requires exactly one argument: the name of a group in the PIPELINE_CSS setting' % token.split_contents()[0]
+        raise template.TemplateSyntaxError('%r requires exactly one argument: the name of a group in the PIPELINE_CSS setting' % token.split_contents()[0])
     return CompressedCSSNode(name)
 compressed_css = register.tag(compressed_css)
 
@@ -107,6 +107,6 @@ def compressed_js(parser, token):
     try:
         tag_name, name = token.split_contents()
     except ValueError:
-        raise template.TemplateSyntaxError, '%r requires exactly one argument: the name of a group in the PIPELINE_JS setting' % token.split_contents()[0]
+        raise template.TemplateSyntaxError('%r requires exactly one argument: the name of a group in the PIPELINE_JS setting' % token.split_contents()[0])
     return CompressedJSNode(name)
 compressed_js = register.tag(compressed_js)


### PR DESCRIPTION
In Python 3, the only acceptable syntax for exception raising with args is the one with the parenthesis. The behavior should be the same in Python 2.
![](http://images2.fanpop.com/image/photos/9700000/Adorable-lil-Kittens-cute-kittens-9781745-1024-768.jpg)
