### PR TITLE
Adds documentation for cache-busting URL support with staticfiles

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -45,7 +45,7 @@ Then when you run ``collectstatic`` command, your CSS and your javascripts will 
     $ python manage.py collectstatic
 
 Cache-busting
-=============
+-------------
 
 Pipeline 1.2+ no longer provides its own cache-busting URL support (using e.g. the ``PIPELINE_VERSIONING`` setting) but uses
 Django's built-in staticfiles support for this. To set up cache-busting in conjunction with ``collectstatic`` as above, use ::


### PR DESCRIPTION
While Pipeline version 1.1.x supported settings such as `PIPELINE_VERSIONING` to manage assets with cache-busting URLs, and more recent versions support this through integration with `django.contrib.staticfiles` and the `pipeline.storage.PipelineCachedStorage` class, this isn't documented anywhere.

This pull request adds such a documentation section.
