### PR TITLE
Stop requiring a Django version bigger than 1.4.2 since that upgrade to ...

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ setup(
     zip_safe=False,
     install_requires=[
         'futures>=2.1.3',
-        'Django>=1.4.2'
     ],
     include_package_data=True,
     classifiers=[


### PR DESCRIPTION
...1.5, too.
