### PR TITLE
Fix issue #196 - Windows machine not allowing for `collectstatic`

### DIFF
--- a/pipeline/storage.py
+++ b/pipeline/storage.py
@@ -110,7 +110,7 @@ class BaseFinderStorage(PipelineStorage):
         return None
 
     def find_storage(self, name):
-        if os.name == 'nt'
+        if os.name == 'nt':
             name = name.replace('/', '\\')
         for finder in finders.get_finders():
             for path, storage in finder.list([]):


### PR DESCRIPTION
This is not the cleanest solution but will at least allow django-pipeline to run `collectstatic` on Windows machines.
