### PR TITLE
add clarification of how the cached storage works in the docs

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -53,6 +53,8 @@ Django's built-in staticfiles support for this. To set up cache-busting in conju
     STATICFILES_STORAGE = 'pipeline.storage.PipelineCachedStorage'
 
 This will handle cache-busting just as ``staticfiles``'s built-in ``CachedStaticFilesStorage`` does.
+Note that when ``debug = False``, this will check the ``STATIC_ROOT`` for combined/minified files on requests.
+Depending on cache settings, these files may be cached due to the expensive nature of hashing file contents.
 
 Middleware
 ==========


### PR DESCRIPTION
I ran into a _very_ confusing configuration issue because of this lack
of clarification in these docs and the django docs. Basically I thought
STATIC_ROOT was _just_ where django collected the static files to and
then the app server never looked at that directory again, but that is
not the case. Instead, django-pipeline will check the STATIC_ROOT on
requests (with caching). STATIC_ROOT must be configured correctly.

We have nginx serving static files on a separate machine and gunicorn
serving our django app. I compiled the static files on a test machine
and then just rsync'd the files to the nginx server and not
the django server because I thought once all the files were compiled
pipeline would know how to find all the cache-busting filenames. It
turns out it can't and that's because on requests it will look in the
STATIC_ROOT. The django app must be able to find the compiled files in
STATIC_ROOT, which is important if you have separate machines for
deploying, static serving, and/or app serving.
