### PR TITLE
Add PIPELINE_ENABLED setting.

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -105,6 +105,13 @@ Group options
 Other settings
 --------------
 
+``PIPELINE_ENABLED``
+....................
+
+  ``True`` if assets should be compressed, ``False`` if not.
+
+  Defaults to ``not settings.DEBUG``.
+
 ``PIPELINE_CSS_COMPRESSOR``
 ............................
 

--- a/pipeline/conf/settings.py
+++ b/pipeline/conf/settings.py
@@ -4,6 +4,8 @@ from django.conf import settings
 
 DEBUG = getattr(settings, 'DEBUG', False)
 
+PIPELINE_ENABLED = getattr(settings, 'PIPELINE_ENABLED', not DEBUG)
+
 PIPELINE_ROOT = getattr(settings, 'PIPELINE_ROOT', settings.STATIC_ROOT)
 PIPELINE_URL = getattr(settings, 'PIPELINE_URL', settings.STATIC_URL)
 

--- a/pipeline/manifest.py
+++ b/pipeline/manifest.py
@@ -33,7 +33,7 @@ class PipelineManifest(Manifest):
     def cache(self):
         ignore_patterns = getattr(settings, "STATICFILES_IGNORE_PATTERNS", None)
 
-        if not settings.DEBUG:
+        if settings.PIPELINE_ENABLED:
             for package in self.packages:
                 self.package_files.append(package.output_filename)
                 yield str(self.packager.individual_url(package.output_filename))

--- a/pipeline/templatetags/compressed.py
+++ b/pipeline/templatetags/compressed.py
@@ -30,7 +30,7 @@ class CompressedMixin(object):
         return packager.package_for(package_type, package_name)
 
     def render_compressed(self, package, package_type):
-        if not settings.DEBUG:
+        if settings.PIPELINE_ENABLED:
             method = getattr(self, "render_{0}".format(package_type))
             return method(package, package.output_filename)
         else:

--- a/tests/tests/test_extension.py
+++ b/tests/tests/test_extension.py
@@ -25,8 +25,8 @@ class ExtensionTest(TestCase):
         template = self.env.from_string(u"""{% compressed_css "screen" %}""")
         self.assertEqual(u'<link href="/static/screen.css" rel="stylesheet" type="text/css" />', template.render())
 
-    def test_package_css_debug(self):
-        with pipeline_settings(DEBUG=True):
+    def test_package_css_disabled(self):
+        with pipeline_settings(PIPELINE_ENABLED=False):
             template = self.env.from_string(u"""{% compressed_css "screen" %}""")
             self.assertEqual(u'''<link href="/static/pipeline/css/first.css" rel="stylesheet" type="text/css" />
 <link href="/static/pipeline/css/second.css" rel="stylesheet" type="text/css" />


### PR DESCRIPTION
This was mentioned as the preferred setting name in issue #178, and I needed it, so here's the implementation; pretty simple of course. Adds support for a `PIPELINE_ENABLED` setting defaulting to `not DEBUG` (so it's backward compatible).

I fixed the existing tests, and would have added more but it seems there currently aren't any tests for the templatetags (or at least I couldn't find them). I suppose those tests could be added with this pull request, but that was more than I had time to set up at the moment.
