### PR TITLE
normalize paths in match_location

### DIFF
--- a/pipeline/storage.py
+++ b/pipeline/storage.py
@@ -103,9 +103,13 @@ class BaseFinderStorage(PipelineStorage):
         if prefix:
             prefix = "%s%s" % (prefix, os.sep)
             name = name[len(prefix):]
-        if path == name:
+
+        norm_path = os.path.normpath(path)
+        norm_name = os.path.normpath(name)
+
+        if norm_path == norm_name:
             return name
-        if os.path.splitext(path)[0] == os.path.splitext(name)[0]:
+        if os.path.splitext(norm_path)[0] == os.path.splitext(norm_name)[0]:
             return name
         return None
 


### PR DESCRIPTION
This solves issue [219](https://github.com/cyberdelia/django-pipeline/issues/219) for me.

The problem in `match_location(self, name, path, prefix)` is that while `name` comes from the settings and is written with forward slashes, `path` comes from the static files finder and could be written with backward slashes (on Windows for example).

We need to normalize them before we can compare them textually.
