### PR TITLE
Compiler was writing new content to files on paths that wasn't findable by the compressor. Fixes #228

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -28,6 +28,7 @@ or just made Pipeline more awesome.
  * Denis V Seleznyov <code@xy2.ru>
  * Fabian Büchler <fabian.buechler@gmail.com>
  * Florent Messa <florent.messa@gmail.com>
+ * Hannes Ljungberg <hannes.ljungberg@gmail.com>
  * Idan Zalzberg <idanzalz@gmail.com>
  * Jannis Leidel <jannis@leidel.info>
  * Jared Scott <jscott@convertro.com>

--- a/pipeline/compilers/__init__.py
+++ b/pipeline/compilers/__init__.py
@@ -32,12 +32,8 @@ class Compiler(object):
                 if compiler.match_file(input_path):
                     output_path = self.output_path(input_path, compiler.output_extension)
                     infile = finders.find(input_path)
-                    outfile = finders.find(output_path)
-                    if outfile is None:
-                        outfile = self.output_path(infile, compiler.output_extension)
-                        outdated = True
-                    else:
-                        outdated = compiler.is_outdated(input_path, output_path)
+                    outfile = self.output_path(infile, compiler.output_extension)
+                    outdated = compiler.is_outdated(input_path, output_path)
                     try:
                         compiler.compile_file(infile, outfile, outdated=outdated, force=force)
                     except CompilerError:


### PR DESCRIPTION
I simply removed the usage of finders.find() to find already created files and let the compiler always use the fallback on building an output-path based on the input-path. The outdated check if is now always done by comparing time modified.

I didn't manage to write any good test cases for this due to the bug being quite complicated to reproduce.

See #228
