### PR TITLE
Ensure file globing is deterministic

### DIFF
--- a/pipeline/glob.py
+++ b/pipeline/glob.py
@@ -15,7 +15,7 @@ def glob(pathname):
     The pattern may contain simple shell-style wildcards a la fnmatch.
 
     """
-    return list(iglob(pathname))
+    return sorted(list(iglob(pathname)))
 
 
 def iglob(pathname):


### PR DESCRIPTION
A small change to ensure the order of filenames returned from glob() is deterministic. This is required to provide consistant file order (and therefore minified file version hashs) when running collectstatic on multiple servers.
