### PR TITLE
Do not include files that have been packaged within the appcache manifesr

### DIFF
--- a/pipeline/manifest.py
+++ b/pipeline/manifest.py
@@ -36,6 +36,7 @@ class PipelineManifest(Manifest):
         if settings.PIPELINE_ENABLED:
             for package in self.packages:
                 self.package_files.append(package.output_filename)
+                self.package_files += package.paths
                 yield str(self.packager.individual_url(package.output_filename))
         else:
             for package in self.packages:


### PR DESCRIPTION
This prevents each package's source files from being included within the manifest.

Example:

Scenario: a.js, b.js, c.js are compressed by pipeline into main.js

Previously:  a.js, b.js, c.js, and main.js would be included in the appcache manifest

Now: Only main.js is included in the appcache manifest

This seems logical, as there should be no reason to include the source files in the manifest as they are all provided by the compressed file anyway.
