### PR TITLE
SubProcessCompressor does not handle well unicode data

### DIFF
--- a/pipeline/compressors/__init__.py
+++ b/pipeline/compressors/__init__.py
@@ -236,4 +236,4 @@ class SubProcessCompressor(CompressorBase):
             raise CompressorError(stderr)
         if self.verbose:
             print(stderr)
-        return stdout
+        return force_text(stdout)

--- a/tests/assets/css/unicode.css
+++ b/tests/assets/css/unicode.css
@@ -1,0 +1,4 @@
+.some_class {
+  // Some unicode
+  content: "áéíóú";
+}

--- a/tests/tests/test_compressor.py
+++ b/tests/tests/test_compressor.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 import base64
+import os.path
 
 try:
     from mock import patch
@@ -10,7 +11,8 @@ except ImportError:
 
 from django.test import TestCase
 
-from pipeline.compressors import Compressor, TEMPLATE_FUNC
+from pipeline.compressors import Compressor, TEMPLATE_FUNC, \
+    SubProcessCompressor
 from pipeline.compressors.yuglify import YuglifyCompressor
 
 from tests.utils import _
@@ -127,3 +129,14 @@ class CompressorTest(TestCase):
 .no-protocol-url {
   background-image: url(//images/sprite-buttons.png);
 }""", output)
+
+    def test_compressor_subprocess_unicode(self):
+        tests_path = os.path.dirname(os.path.dirname(__file__))
+        output = SubProcessCompressor(False).execute_command(
+            '/usr/bin/env cat',
+            open(tests_path + '/assets/css/unicode.css').read())
+        self.assertEqual(""".some_class {
+  // Some unicode
+  content: "áéíóú";
+}
+""", output)


### PR DESCRIPTION
`SubProcessCompressor.execute_command` always returns ascii even when the file contains unicode data.
