### PR TITLE
Include documentation sources in PyPi releases.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,5 @@ recursive-include pipeline/templates *.html *.jinja
 include AUTHORS LICENSE README.rst HISTORY.rst
 recursive-include tests *
 recursive-exclude tests *.pyc *.pyo
+include docs/Makefile docs/make.bat docs/conf.py
+recursive-include docs *.rst


### PR DESCRIPTION
The files `docs/` weren't included in `MANIFEST.in` and therefore `sdist` tarballs on PyPi lacked sources necessary to build docs. This patch adds the sources.
