### PR TITLE
Documenting the default JS template behavior w/ extra_context

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -91,6 +91,12 @@ Group options
 
   For CSS, if you do not specify ``extra_context``/``media``, the default media in
   the ``<link>`` output will be ``media="all"``.
+  
+  For JS, the default templates support the ``async`` and ``defer`` tag attributes which are controlled via ``extra_context``: ::
+  
+    'extra_context': {
+        'async': True,
+    },
 
 ``manifest``
 ............


### PR DESCRIPTION
Support for the async and defer tag attributes is not documented and requires examining the source.

Let me know if I should do this in a separate branch. Thanks!
