### PR TITLE
Fix Python 3 compatibility

### DIFF
--- a/pipeline/finders.py
+++ b/pipeline/finders.py
@@ -1,8 +1,9 @@
+from itertools import chain
+
 from django.contrib.staticfiles.finders import BaseFinder, AppDirectoriesFinder, FileSystemFinder, find
 from django.utils._os import safe_join
 
 from pipeline.conf import settings
-
 
 class PipelineFinder(BaseFinder):
     def find(self, path, all=False):
@@ -10,7 +11,7 @@ class PipelineFinder(BaseFinder):
         Looks for files in PIPELINE_CSS and PIPELINE_JS
         """
         matches = []
-        for elem in settings.PIPELINE_CSS.values() + settings.PIPELINE_JS.values():
+        for elem in chain(settings.PIPELINE_CSS.values(), settings.PIPELINE_JS.values()):
             if elem['output_filename'] == path:
                 match = safe_join(settings.PIPELINE_ROOT, path)
                 if not all:

--- a/pipeline/glob.py
+++ b/pipeline/glob.py
@@ -63,7 +63,7 @@ def glob1(dirname, pattern):
         # and storage implementations are really exotic.
         return []
     if pattern[0] != '.':
-        names = filter(lambda x: x[0] != '.', names)
+        names = [x for x in names if x[0] != '.']
     return fnmatch.filter(names, pattern)
 
 

--- a/pipeline/utils.py
+++ b/pipeline/utils.py
@@ -2,7 +2,11 @@ from __future__ import unicode_literals
 
 import mimetypes
 import posixpath
-import urllib
+
+try:
+    from urllib.parse import quote
+except ImportError:
+    from urllib import quote
 
 from django.utils import importlib
 from django.utils.encoding import smart_str
@@ -23,7 +27,7 @@ def to_class(class_str):
 def filepath_to_uri(path):
     if path is None:
         return path
-    return urllib.quote(smart_str(path).replace("\\", "/"), safe="/~!*()'#?")
+    return quote(smart_str(path).replace("\\", "/"), safe="/~!*()'#?")
 
 
 def guess_type(path, default=None):


### PR DESCRIPTION
Python 3 compatibility has been lost. Readd it.

finders.py: use chain to concatenate dictionaries instead of + operator.
glob.py: use list compresension instead of filter and lambda.
utils.py: use urllib.parse.quote instead urllib.quote if available.
