### PR TITLE
prevent pipeline from dying on Closure Compiler warnings

### DIFF
--- a/pipeline/compressors/__init__.py
+++ b/pipeline/compressors/__init__.py
@@ -232,8 +232,8 @@ class SubProcessCompressor(CompressorBase):
         if content:
             content = smart_bytes(content)
         stdout, stderr = pipe.communicate(content)
-        if stderr.strip():
+        if stderr.strip() and pipe.returncode != 0:
             raise CompressorError(stderr)
-        if self.verbose:
+        elif self.verbose:
             print(stderr)
         return force_text(stdout)


### PR DESCRIPTION
The Closure compiler will emit both warnings and errors to stderr.  I added the return code check so that compression will succeed if there are no errors.  Also, the print(stderr) was a noop since any stderr would always raise a CompressorError, but now it can actually be used.
