### PR TITLE
Added outdated and force support to LessCompiler

### DIFF
--- a/pipeline/compilers/less.py
+++ b/pipeline/compilers/less.py
@@ -13,6 +13,8 @@ class LessCompiler(SubProcessCompiler):
         return filename.endswith('.less')
 
     def compile_file(self, infile, outfile, outdated=False, force=False):
+        if not outdated and not force:
+            return  # File doesn't need to be recompiled
         command = "%s %s %s %s" % (
             settings.PIPELINE_LESS_BINARY,
             settings.PIPELINE_LESS_ARGUMENTS,


### PR DESCRIPTION
Resolved what appears to be a minor bug causing less complication to occur despite the .css to not be outdated.  This is now consistent with how the CoffeeCompiler behaves.
