### PR TITLE
Mime types should not be unicode strings

### DIFF
--- a/pipeline/conf.py
+++ b/pipeline/conf.py
@@ -63,11 +63,11 @@ DEFAULTS = {
     'PIPELINE_LESS_ARGUMENTS': '',
 
     'PIPELINE_MIMETYPES': (
-        ('text/coffeescript', '.coffee'),
-        ('text/less', '.less'),
-        ('text/javascript', '.js'),
-        ('text/x-sass', '.sass'),
-        ('text/x-scss', '.scss')
+        (b'text/coffeescript', '.coffee'),
+        (b'text/less', '.less'),
+        (b'text/javascript', '.js'),
+        (b'text/x-sass', '.sass'),
+        (b'text/x-scss', '.scss')
     ),
 
     'PIPELINE_EMBED_MAX_IMAGE_SIZE': 32700,


### PR DESCRIPTION
The mimetypes are added to the standard library's "mimetypes" module. From there they end up being fed back to anything else that asks. In my setup they ended up getting given to wsgiref as a header value and it choked (because it expects headers to be byte strings not unicode strings).

In general I'm not sure it's a good idea to change the mimetype's idea of what a .js file is from application/javascript (the default) to text/javascript even if it wasn't also setting it to a unicode string.
