### PR TITLE
First example should probably say PipelineStorage

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -44,7 +44,7 @@ Collect static
 
 Pipeline integrates with staticfiles, you just need to setup ``STATICFILES_STORAGE`` to ::
 
-    STATICFILES_STORAGE = 'pipeline.storage.PipelineCachedStorage'
+    STATICFILES_STORAGE = 'pipeline.storage.PipelineStorage'
 
 Then when you run ``collectstatic`` command, your CSS and your javascripts will be compressed in the same time ::
 


### PR DESCRIPTION
First example in documentation should refer to ordinary PipelineStorage rather than PipelineCachedStorage, which is covered in the "Cache-busting" section below.
