### PR TITLE
Bumped django dependency

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -21,7 +21,7 @@ Installation
 
 
 .. note::
-  You need to use ``Django>=1.4.2`` to be able to use this version of pipeline.
+  You need to use ``Django>=1.5`` to be able to use this version of pipeline.
 
 .. _GitHub: http://github.com/cyberdelia/django-pipeline
 .. _PyPI: http://pypi.python.org/pypi/django-pipeline


### PR DESCRIPTION
This is in response to https://github.com/cyberdelia/django-pipeline/issues/312 - where I learned pipeline was breaking due to using an [unsupported django version](https://github.com/cyberdelia/django-pipeline/issues/312#issuecomment-33757169)
