### PR TITLE
PipelineStorage.listdir short-circuit returning the first match only

### DIFF
--- a/pipeline/storage.py
+++ b/pipeline/storage.py
@@ -128,12 +128,17 @@ class BaseFinderStorage(PipelineStorage):
         return exists
 
     def listdir(self, path):
+        directories, files = [], []
         for finder in self.finders.get_finders():
             for storage in finder.storages.values():
                 try:
-                    return storage.listdir(path)
+                    new_directories, new_files = storage.listdir(path)
                 except OSError:
                     pass
+                else:
+                    directories.extend(new_directories)
+                    files.extend(new_files)
+        return directories, files
 
     def find_storage(self, name):
         for finder in self.finders.get_finders():


### PR DESCRIPTION
I have been using pipeline for awhile and like the way it integrates with my workflow. However, I encountered an issue while trying to use \* for globbing on a directory that exists in every app folder, like this:

``` python
PIPELINE_JS = {
    'templates': {
        'source_filenames': (
            'js/templates/*/*.dust',     # I made a custom compiler for that
        ),
        'output_filename': 'js/templates.min.js',
    },
}
```

This way, {{ compressed_js 'templates }} only includes the files of the first directory that matches. Sample directory tree:
- myappA/static/js/templates/myappA/mytemplate1.dust
- myappA/static/js/templates/myappA/mytemplate2.dust
- myappB/static/js/templates/myappB/mytemplate3.dust
- myappB/static/js/templates/myappB/mytemplate4.dust

I narrowed down the issue to glob1's call to listdir on the default storage (that proxies to a PipelineFinderStorage instance). What seems to happen is glob1 expects listdir to return all files in 'js/templates', but listdir only lists stuff in **the first** storage that has a 'js/templates'.

Attached pull request fixes the issue for me. Unfortunately I am not familiar enough with the codebase to do proper testing.
