### PR TITLE
properly decode README.rst and HISTORY.rst

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,8 @@ setup(
     name='django-pipeline',
     version='1.3.22',
     description='Pipeline is an asset packaging library for Django.',
-    long_description=open('README.rst').read() + '\n\n' +
-        open('HISTORY.rst').read(),
+    long_description=open('README.rst', 'rb').read().decode('utf-8') + '\n\n' +
+        open('HISTORY.rst', 'rb').read().decode('utf-8'),
     author='Timothée Peignier',
     author_email='timothee.peignier@tryphon.org',
     url='https://github.com/cyberdelia/django-pipeline',


### PR DESCRIPTION
HISTORY.rst has non-ASCII characters in it. The open('HISTORY.rst').read() trick works fine on Python 2, where you get the literal UTF-8 bytes. On Python 3, though, you at the mercy of the default file encoding, which may be ASCII (if LANG='en_US.ASCII' for example). Therefore, we need to explicitly decode with UTF-8 to prevent error on those poor systems.
