### PR TITLE
don't fail on finders without storages attribute

### DIFF
--- a/pipeline/storage.py
+++ b/pipeline/storage.py
@@ -131,14 +131,19 @@ class BaseFinderStorage(PipelineStorage):
     def listdir(self, path):
         directories, files = [], []
         for finder in self.finders.get_finders():
-            for storage in finder.storages.values():
-                try:
-                    new_directories, new_files = storage.listdir(path)
-                except OSError:
-                    pass
-                else:
-                    directories.extend(new_directories)
-                    files.extend(new_files)
+            try:
+                storages = finder.storages.values()
+            except AttributeError:
+                continue
+            else:
+                for storage in storages:
+                    try:
+                        new_directories, new_files = storage.listdir(path)
+                    except OSError:
+                        pass
+                    else:
+                        directories.extend(new_directories)
+                        files.extend(new_files)
         return directories, files
 
     def find_storage(self, name):


### PR DESCRIPTION
I'm using https://github.com/ifanrx/django-dajaxice and after upgrading to 1.3.23 not all css files are loaded with css tag. It turns out that pipeline was failing on `finder.storages.values()` call since finder in dajaxice doesn't have storages attribute. It was working with <1.3.22 since there was return before it reached dajaxice finder.
