### PR TITLE
'zip' in GZIPMixin should be capitalized

### DIFF
--- a/docs/storages.rst
+++ b/docs/storages.rst
@@ -60,7 +60,7 @@ so that you can avoid compressing them on the fly. ::
 
   STATICFILES_STORAGE = 'your.app.GZIPCachedStorage'
 
-The storage need to inherit from ``GzipMixin``: ::
+The storage need to inherit from ``GZIPMixin``: ::
 
   from staticfiles.storage import CachedStaticFilesStorage
 


### PR DESCRIPTION
Hi, I noticed this small typo while reading the documentation
