### PR TITLE
Fixed exception on missing files with 2 extensions

### DIFF
--- a/pipeline/finders.py
+++ b/pipeline/finders.py
@@ -32,7 +32,10 @@ class CachedFileFinder(BaseFinder):
         try:
             start, _, extn = path.rsplit('.', 2)
             path = '.'.join((start, extn))
-            return find(path, all=all)
+            result = find(path, all=all)
+            if not result:
+                return []
+            return result
         except ValueError:
             return []
 

--- a/tests/tests/test_storage.py
+++ b/tests/tests/test_storage.py
@@ -1,6 +1,8 @@
 from __future__ import unicode_literals
 
 from django.test import TestCase
+from django.conf import settings
+from django.contrib.staticfiles import finders
 
 from pipeline.storage import PipelineStorage, PipelineFinderStorage
 
@@ -26,3 +28,27 @@ class StorageTest(TestCase):
             storage.find_storage('app.css')
         except ValueError:
             self.fail()
+
+    def test_nonexistent_file_pipeline_finder(self):
+        CUSTOM_FINDERS = settings.STATICFILES_FINDERS + ('pipeline.finders.PipelineFinder',)
+        with self.settings(STATICFILES_FINDERS=CUSTOM_FINDERS):
+            path = finders.find('nothing.css')
+            self.assertIsNone(path)
+
+    def test_nonexistent_file_cached_finder(self):
+        CUSTOM_FINDERS = settings.STATICFILES_FINDERS + ('pipeline.finders.CachedFileFinder',)
+        with self.settings(STATICFILES_FINDERS=CUSTOM_FINDERS):
+            path = finders.find('nothing.css')
+            self.assertIsNone(path)
+
+    def test_nonexistent_double_extension_file_pipeline_finder(self):
+        CUSTOM_FINDERS = settings.STATICFILES_FINDERS + ('pipeline.finders.PipelineFinder',)
+        with self.settings(STATICFILES_FINDERS=CUSTOM_FINDERS):
+            path = finders.find('app.css.map')
+            self.assertIsNone(path)
+
+    def test_nonexistent_double_extension_file_cached_finder(self):
+        CUSTOM_FINDERS = settings.STATICFILES_FINDERS + ('pipeline.finders.CachedFileFinder',)
+        with self.settings(STATICFILES_FINDERS=CUSTOM_FINDERS):
+            path = finders.find('app.css.map')
+            self.assertIsNone(path)


### PR DESCRIPTION
If there's a request for a file with 2 extensions, such as "style.css.map" the CachedFileFinder will recursively try to find "style.map" which probably doesn't exist.  This is fine, except that when the argument 'all' is False, django.contrib.staticfiles.finders.find() will return None instead of an empty list.  find() itself always expects the finders to return a list, never None, and so in the end, a result of [None] will get returned to the staticfiles serve() view, instead of just None, and it will try to treat the list as a string, thus throwing an exception.  My fix guarantees that an empty list is always returned from CachedFileFinder.find() if the recursive call to find() doesn't find anything.
