### PR TITLE
Add `*.styl` to built-in finders' ignore patterns

### DIFF
--- a/pipeline/finders.py
+++ b/pipeline/finders.py
@@ -65,6 +65,7 @@ class AppDirectoriesFinder(PatternFilterMixin, AppDirectoriesFinder):
         '*.css',
         '*.less',
         '*.scss',
+        '*.styl',
     ]
 
 
@@ -79,6 +80,7 @@ class FileSystemFinder(PatternFilterMixin, FileSystemFinder):
         '*.js',
         '*.less',
         '*.scss',
+        '*.styl',
         '*.sh',
         '*.html',
         '*.md',


### PR DESCRIPTION
I'm using the Stylus compiler and `*.styl` files were being copied into my `STATIC_ROOT` folder. This commit fixes it.
