### PR TITLE
Add new setting in order to control concurrency in virtualized environments.

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -118,6 +118,14 @@ Other settings
 
   Defaults to ``not settings.DEBUG``.
 
+``PIPELINE_COMPILER_CONCURRENCY``
+.................................
+
+  If set, overrides the number of threads used to compile assets. Otherwise the
+  compiler will attempt to use as many threads as there are available cores.
+
+  Defaults to ``None``.
+
 ``PIPELINE_CSS_COMPRESSOR``
 ............................
 

--- a/pipeline/compilers/__init__.py
+++ b/pipeline/compilers/__init__.py
@@ -51,7 +51,12 @@ class Compiler(object):
         except ImportError:
             return list(map(_compile, paths))
         else:
-            with futures.ThreadPoolExecutor(max_workers=multiprocessing.cpu_count()) as executor:
+            max_workers = (
+                settings.PIPELINE_COMPILER_CONCURRENCY or
+                multiprocessing.cpu_count())
+            with futures.ThreadPoolExecutor(
+                max_workers=max_workers
+            ) as executor:
                 return list(executor.map(_compile, paths))
 
     def output_path(self, path, extension):

--- a/pipeline/conf.py
+++ b/pipeline/conf.py
@@ -16,6 +16,7 @@ DEFAULTS = {
     'PIPELINE_CSS_COMPRESSOR': 'pipeline.compressors.yuglify.YuglifyCompressor',
     'PIPELINE_JS_COMPRESSOR': 'pipeline.compressors.yuglify.YuglifyCompressor',
     'PIPELINE_COMPILERS': [],
+    'PIPELINE_COMPILER_CONCURRENCY': None,
 
     'PIPELINE_CSS': {},
     'PIPELINE_JS': {},

--- a/tests/tests/test_compiler.py
+++ b/tests/tests/test_compiler.py
@@ -1,7 +1,10 @@
 from __future__ import unicode_literals
 
 from django.test import TestCase
-from mock import MagicMock, patch
+try:
+    from mock import MagicMock, patch
+except ImportError:
+    from unittest.mock import MagicMock, patch
 
 from pipeline.conf import settings
 from pipeline.compilers import Compiler, CompilerBase

--- a/tests/tests/test_compiler.py
+++ b/tests/tests/test_compiler.py
@@ -43,7 +43,7 @@ class CompilerTest(TestCase):
         ])
         self.assertEqual([_('pipeline/js/dummy.js'), _('pipeline/js/application.js')], list(paths))
 
-    def _get_mocked_concurrency_packages(self, mock_cpu_count=4):
+    def _get_mocked_concurrency_packages(self, mock_cpu_count):
         multiprocessing_mock = MagicMock()
         multiprocessing_mock.cpu_count.return_value = mock_cpu_count
 
@@ -64,7 +64,7 @@ class CompilerTest(TestCase):
         CPU count.
         '''
         modules, thread_pool_executor_mock = (
-            self._get_mocked_concurrency_packages())
+            self._get_mocked_concurrency_packages(mock_cpu_count=4))
 
         settings.PIPELINE_COMPILER_CONCURRENCY = 2
 


### PR DESCRIPTION
This is a fix for an issue that I ran into when trying to use django-pipeline in Circle CI. 

Circle CI is a virtualized environment using Docker containers. django-pipeline attempts to compile assets concurrently (even if PIPELINE_ENABLED is False). Circle CI virtual hosts have 32 cores and that's exactly what the container sees, even though it only really has access to 2 of those cores. When django-pipeline attempts to use all 32 cores, it fails catastrophically with a SIGABRT.

This setting allows users to override the concurrency instead of allowing django-pipeline to use as many threads as it thinks there are cores.
