### PR TITLE
ignore_filenames

### DIFF
--- a/pipeline/packager.py
+++ b/pipeline/packager.py
@@ -21,19 +21,23 @@ class Package(object):
     @property
     def sources(self):
         def _findfiles(patterns):
-            paths = set()
+            paths = []
             for pattern in patterns:
                 for path in glob(pattern):
                     if path not in paths and find(path):
-                        paths.add(str(path))
+                        paths.append(str(path))
             return paths
 
         if not self._sources:
             source_filenames = self.config.get('source_filenames', [])
             ignore_filenames = self.config.get('ignore_filenames', [])
-            source_paths = _findfiles(source_filenames)
-            ignore_paths = _findfiles(ignore_filenames)
-            self._sources = list(source_paths - ignore_paths)
+            source_paths = _findfiles(source_filenames) # we should keep order
+            ignore_paths = set(_findfiles(ignore_filenames)) # we can ignore order
+            paths = []
+            for path in source_paths:
+                if path not in ignore_paths:
+                    paths.append(path)
+            self._sources = paths
         return self._sources
 
 

--- a/pipeline/packager.py
+++ b/pipeline/packager.py
@@ -20,14 +20,22 @@ class Package(object):
 
     @property
     def sources(self):
-        if not self._sources:
-            paths = []
-            for pattern in self.config.get('source_filenames', []):
+        def _findfiles(patterns):
+            paths = set()
+            for pattern in patterns:
                 for path in glob(pattern):
                     if path not in paths and find(path):
-                        paths.append(str(path))
-            self._sources = paths
+                        paths.add(str(path))
+            return paths
+
+        if not self._sources:
+            source_filenames = self.config.get('source_filenames', [])
+            ignore_filenames = self.config.get('ignore_filenames', [])
+            source_paths = _findfiles(source_filenames)
+            ignore_paths = _findfiles(ignore_filenames)
+            self._sources = list(source_paths - ignore_paths)
         return self._sources
+
 
     @property
     def paths(self):


### PR DESCRIPTION
Hi, I added ability to ignore some files with **ignore_filenames** option.

    PIPELINE_CSS = {
        'all': {
            'source_filenames': (
                'blocks/*/*.css',
            ),
            'ignore_filenames': (
                'blocks/*/*.ie*.css',
            ),
            'output_filename': '_all.css',
        },