### PR TITLE
Make compilers run directly, not inside shells

### DIFF
--- a/pipeline/compilers/__init__.py
+++ b/pipeline/compilers/__init__.py
@@ -99,8 +99,8 @@ class SubProcessCompiler(CompilerBase):
         import subprocess
         output_file = subprocess.PIPE
         if stdout_captured:
-            output_file = tempfile.NamedTemporaryFile(delete=False, 
-                    dir=cwd or os.path.dirname(stdout_captured) or os.cwd)
+            output_file = tempfile.NamedTemporaryFile(delete=False,
+                    dir=cwd or os.path.dirname(stdout_captured) or os.getcwd())
         try:
             pipe = subprocess.Popen(argument_list, cwd=cwd,
                                     stdout=output_file, stdin=subprocess.PIPE,

--- a/pipeline/compilers/__init__.py
+++ b/pipeline/compilers/__init__.py
@@ -106,7 +106,7 @@ class SubProcessCompiler(CompilerBase):
 
         argument_list = []
         for flattening_arg in command:
-            if isinstance(flattening_arg, str):
+            if isinstance(flattening_arg, (type(u""), type(b""))):
                 argument_list.append(flattening_arg)
             else:
                 argument_list.extend(flattening_arg)

--- a/pipeline/compilers/__init__.py
+++ b/pipeline/compilers/__init__.py
@@ -86,7 +86,7 @@ class CompilerBase(object):
 
 
 class SubProcessCompiler(CompilerBase):
-    def execute_command(self, command, content=None, cwd=None, stdout_as_result=None):
+    def execute_command(self, command, content=None, cwd=None, stdout_captured=None):
         argument_list = []
         for arg in command:
             if isinstance(arg, str):
@@ -98,9 +98,9 @@ class SubProcessCompiler(CompilerBase):
 
         import subprocess
         output_file = subprocess.PIPE
-        if stdout_as_result:
+        if stdout_captured:
             output_file = tempfile.NamedTemporaryFile(delete=False, 
-                    dir=cwd or os.path.dirname(stdout_as_result) or os.cwd)
+                    dir=cwd or os.path.dirname(stdout_captured) or os.cwd)
         try:
             pipe = subprocess.Popen(argument_list, cwd=cwd,
                                     stdout=output_file, stdin=subprocess.PIPE,
@@ -120,5 +120,5 @@ class SubProcessCompiler(CompilerBase):
         if pipe.returncode != 0:
             raise CompilerError("Command '{0}' returned non-zero exit status {1}".format(command, pipe.returncode))
         if stdout_as_result:
-            os.rename(output_file.name, os.path.join(cwd or os.curdir, stdout_as_result))
+            os.rename(output_file.name, os.path.join(cwd or os.curdir, stdout_captured))
         return stdout

--- a/pipeline/compilers/__init__.py
+++ b/pipeline/compilers/__init__.py
@@ -87,13 +87,22 @@ class CompilerBase(object):
 
 class SubProcessCompiler(CompilerBase):
     def execute_command(self, command, content=None, cwd=None, stdout_as_result=None):
+        argument_list = []
+        for arg in command:
+            if isinstance(arg, str):
+                argument_list.append(arg)
+            else:
+                argument_list.extend(arg)
+                # Flatten one layer of command lists here to make compiler
+                # modules simple.
+
         import subprocess
         output_file = subprocess.PIPE
         if stdout_as_result:
             output_file = tempfile.NamedTemporaryFile(delete=False, 
                     dir=cwd or os.path.dirname(stdout_as_result) or os.cwd)
         try:
-            pipe = subprocess.Popen(command, cwd=cwd,
+            pipe = subprocess.Popen(argument_list, cwd=cwd,
                                     stdout=output_file, stdin=subprocess.PIPE,
                                     stderr=subprocess.PIPE)
             if content:

--- a/pipeline/compilers/__init__.py
+++ b/pipeline/compilers/__init__.py
@@ -90,7 +90,8 @@ class SubProcessCompiler(CompilerBase):
         import subprocess
         output_file = subprocess.PIPE
         if stdout_as_result:
-            output_file = tempfile.NamedTemporaryFile(delete=False)
+            output_file = tempfile.NamedTemporaryFile(delete=False, 
+                    dir=cwd or os.path.dirname(stdout_as_result) or os.cwd)
         try:
             pipe = subprocess.Popen(command, cwd=cwd,
                                     stdout=output_file, stdin=subprocess.PIPE,

--- a/pipeline/compilers/coffee.py
+++ b/pipeline/compilers/coffee.py
@@ -1,7 +1,5 @@
 from __future__ import unicode_literals
 
-import shlex
-
 from pipeline.conf import settings
 from pipeline.compilers import SubProcessCompiler
 
@@ -18,7 +16,7 @@ class CoffeeScriptCompiler(SubProcessCompiler):
         command = (
             settings.PIPELINE_COFFEE_SCRIPT_BINARY,
             "-cp",
-        ) + tuple(shlex.split(settings.PIPELINE_COFFEE_SCRIPT_ARGUMENTS)) + (
+            settings.PIPELINE_COFFEE_SCRIPT_ARGUMENTS,
             infile,
         )
         return self.execute_command(command, stdout_as_result=outfile)

--- a/pipeline/compilers/coffee.py
+++ b/pipeline/compilers/coffee.py
@@ -19,4 +19,4 @@ class CoffeeScriptCompiler(SubProcessCompiler):
             settings.PIPELINE_COFFEE_SCRIPT_ARGUMENTS,
             infile,
         )
-        return self.execute_command(command, stdout_as_result=outfile)
+        return self.execute_command(command, stdout_captured=outfile)

--- a/pipeline/compilers/coffee.py
+++ b/pipeline/compilers/coffee.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
 
+import shlex
+
 from pipeline.conf import settings
 from pipeline.compilers import SubProcessCompiler
 
@@ -13,10 +15,10 @@ class CoffeeScriptCompiler(SubProcessCompiler):
     def compile_file(self, infile, outfile, outdated=False, force=False):
         if not outdated and not force:
             return  # File doesn't need to be recompiled
-        command = "%s -cp %s %s > %s" % (
+        command = (
             settings.PIPELINE_COFFEE_SCRIPT_BINARY,
-            settings.PIPELINE_COFFEE_SCRIPT_ARGUMENTS,
+            "-cp",
+        ) + tuple(shlex.split(settings.PIPELINE_COFFEE_SCRIPT_ARGUMENTS)) + (
             infile,
-            outfile
         )
-        return self.execute_command(command)
+        return self.execute_command(command, stdout_as_result=outfile)

--- a/pipeline/compilers/es6.py
+++ b/pipeline/compilers/es6.py
@@ -16,7 +16,7 @@ class ES6Compiler(SubProcessCompiler):
             return  # File doesn't need to be recompiled
         command = (
             settings.PIPELINE_BABEL_BINARY,
-            settings.PIPELINE_BABEL_SCRIPT_ARGUMENTS,
+            settings.PIPELINE_BABEL_ARGUMENTS,
             infile,
             "-o",
             outfile

--- a/pipeline/compilers/es6.py
+++ b/pipeline/compilers/es6.py
@@ -1,5 +1,8 @@
 from __future__ import unicode_literals
 
+import shlex
+
+from pipeline.conf import settings
 from pipeline.conf import settings
 from pipeline.compilers import SubProcessCompiler
 
@@ -13,10 +16,11 @@ class ES6Compiler(SubProcessCompiler):
     def compile_file(self, infile, outfile, outdated=False, force=False):
         if not outdated and not force:
             return  # File doesn't need to be recompiled
-        command = "%s %s %s -o %s" % (
+        command = (
             settings.PIPELINE_BABEL_BINARY,
-            settings.PIPELINE_BABEL_ARGUMENTS,
+        ) + tuple(shlex.split(settings.PIPELINE_BABEL_SCRIPT_ARGUMENTS)) + (
             infile,
+            "-o",
             outfile
         )
         return self.execute_command(command)

--- a/pipeline/compilers/es6.py
+++ b/pipeline/compilers/es6.py
@@ -1,7 +1,5 @@
 from __future__ import unicode_literals
 
-import shlex
-
 from pipeline.conf import settings
 from pipeline.conf import settings
 from pipeline.compilers import SubProcessCompiler
@@ -18,7 +16,7 @@ class ES6Compiler(SubProcessCompiler):
             return  # File doesn't need to be recompiled
         command = (
             settings.PIPELINE_BABEL_BINARY,
-        ) + tuple(shlex.split(settings.PIPELINE_BABEL_SCRIPT_ARGUMENTS)) + (
+            settings.PIPELINE_BABEL_SCRIPT_ARGUMENTS,
             infile,
             "-o",
             outfile

--- a/pipeline/compilers/less.py
+++ b/pipeline/compilers/less.py
@@ -1,5 +1,8 @@
 from __future__ import unicode_literals
 
+import shlex
+
+from pipeline.conf import settings
 from os.path import dirname
 
 from pipeline.conf import settings
@@ -14,10 +17,9 @@ class LessCompiler(SubProcessCompiler):
 
     def compile_file(self, infile, outfile, outdated=False, force=False):
         # Pipe to file rather than provide outfile arg due to a bug in lessc
-        command = "%s %s %s > %s" % (
+        command = (
             settings.PIPELINE_LESS_BINARY,
-            settings.PIPELINE_LESS_ARGUMENTS,
+        ) + tuple(shlex.split(settings.PIPELINE_LESS_SCRIPT_ARGUMENTS)) + (
             infile,
-            outfile
         )
-        return self.execute_command(command, cwd=dirname(infile))
+        return self.execute_command(command, cwd=dirname(infile), stdout_as_result=outfile)

--- a/pipeline/compilers/less.py
+++ b/pipeline/compilers/less.py
@@ -1,7 +1,5 @@
 from __future__ import unicode_literals
 
-import shlex
-
 from pipeline.conf import settings
 from os.path import dirname
 
@@ -19,7 +17,7 @@ class LessCompiler(SubProcessCompiler):
         # Pipe to file rather than provide outfile arg due to a bug in lessc
         command = (
             settings.PIPELINE_LESS_BINARY,
-        ) + tuple(shlex.split(settings.PIPELINE_LESS_SCRIPT_ARGUMENTS)) + (
+            settings.PIPELINE_LESS_SCRIPT_ARGUMENTS,
             infile,
         )
         return self.execute_command(command, cwd=dirname(infile), stdout_as_result=outfile)

--- a/pipeline/compilers/less.py
+++ b/pipeline/compilers/less.py
@@ -17,7 +17,7 @@ class LessCompiler(SubProcessCompiler):
         # Pipe to file rather than provide outfile arg due to a bug in lessc
         command = (
             settings.PIPELINE_LESS_BINARY,
-            settings.PIPELINE_LESS_SCRIPT_ARGUMENTS,
+            settings.PIPELINE_LESS_ARGUMENTS,
             infile,
         )
         return self.execute_command(command, cwd=dirname(infile), stdout_as_result=outfile)

--- a/pipeline/compilers/less.py
+++ b/pipeline/compilers/less.py
@@ -20,4 +20,4 @@ class LessCompiler(SubProcessCompiler):
             settings.PIPELINE_LESS_ARGUMENTS,
             infile,
         )
-        return self.execute_command(command, cwd=dirname(infile), stdout_as_result=outfile)
+        return self.execute_command(command, cwd=dirname(infile), stdout_captured=outfile)

--- a/pipeline/compilers/livescript.py
+++ b/pipeline/compilers/livescript.py
@@ -1,5 +1,8 @@
 from __future__ import unicode_literals
 
+import shlex
+
+from pipeline.conf import settings
 from pipeline.conf import settings
 from pipeline.compilers import SubProcessCompiler
 
@@ -13,10 +16,10 @@ class LiveScriptCompiler(SubProcessCompiler):
     def compile_file(self, infile, outfile, outdated=False, force=False):
         if not outdated and not force:
             return  # File doesn't need to be recompiled
-        command = "%s -cp %s %s > %s" % (
+        command = (
             settings.PIPELINE_LIVE_SCRIPT_BINARY,
-            settings.PIPELINE_LIVE_SCRIPT_ARGUMENTS,
+            "-cp",
+        ) + tuple(shlex.split(settings.PIPELINE_LIVE_SCRIPT_ARGUMENTS)) + (
             infile,
-            outfile
         )
-        return self.execute_command(command)
+        return self.execute_command(command, stdout_as_result=outfile)

--- a/pipeline/compilers/livescript.py
+++ b/pipeline/compilers/livescript.py
@@ -1,7 +1,5 @@
 from __future__ import unicode_literals
 
-import shlex
-
 from pipeline.conf import settings
 from pipeline.conf import settings
 from pipeline.compilers import SubProcessCompiler
@@ -19,7 +17,7 @@ class LiveScriptCompiler(SubProcessCompiler):
         command = (
             settings.PIPELINE_LIVE_SCRIPT_BINARY,
             "-cp",
-        ) + tuple(shlex.split(settings.PIPELINE_LIVE_SCRIPT_ARGUMENTS)) + (
+            settings.PIPELINE_LIVE_SCRIPT_ARGUMENTS,
             infile,
         )
         return self.execute_command(command, stdout_as_result=outfile)

--- a/pipeline/compilers/livescript.py
+++ b/pipeline/compilers/livescript.py
@@ -20,4 +20,4 @@ class LiveScriptCompiler(SubProcessCompiler):
             settings.PIPELINE_LIVE_SCRIPT_ARGUMENTS,
             infile,
         )
-        return self.execute_command(command, stdout_as_result=outfile)
+        return self.execute_command(command, stdout_captured=outfile)

--- a/pipeline/compilers/sass.py
+++ b/pipeline/compilers/sass.py
@@ -1,5 +1,8 @@
 from __future__ import unicode_literals
 
+import shlex
+
+from pipeline.conf import settings
 from os.path import dirname
 
 from pipeline.conf import settings
@@ -13,9 +16,9 @@ class SASSCompiler(SubProcessCompiler):
         return filename.endswith(('.scss', '.sass'))
 
     def compile_file(self, infile, outfile, outdated=False, force=False):
-        command = "%s %s %s %s" % (
+        command = (
             settings.PIPELINE_SASS_BINARY,
-            settings.PIPELINE_SASS_ARGUMENTS,
+        ) + tuple(shlex.split(settings.PIPELINE_SASS_ARGUMENTS)) + (
             infile,
             outfile
         )

--- a/pipeline/compilers/sass.py
+++ b/pipeline/compilers/sass.py
@@ -1,7 +1,5 @@
 from __future__ import unicode_literals
 
-import shlex
-
 from pipeline.conf import settings
 from os.path import dirname
 
@@ -18,7 +16,7 @@ class SASSCompiler(SubProcessCompiler):
     def compile_file(self, infile, outfile, outdated=False, force=False):
         command = (
             settings.PIPELINE_SASS_BINARY,
-        ) + tuple(shlex.split(settings.PIPELINE_SASS_ARGUMENTS)) + (
+            settings.PIPELINE_SASS_ARGUMENTS,
             infile,
             outfile
         )

--- a/pipeline/compilers/stylus.py
+++ b/pipeline/compilers/stylus.py
@@ -1,5 +1,8 @@
 from __future__ import unicode_literals
 
+import shlex
+
+from pipeline.conf import settings
 from os.path import dirname
 
 from pipeline.conf import settings
@@ -13,9 +16,9 @@ class StylusCompiler(SubProcessCompiler):
         return filename.endswith('.styl')
 
     def compile_file(self, infile, outfile, outdated=False, force=False):
-        command = "%s %s %s" % (
+        command = (
             settings.PIPELINE_STYLUS_BINARY,
-            settings.PIPELINE_STYLUS_ARGUMENTS,
+        ) + tuple(shlex.split(settings.PIPELINE_STYLUS_ARGUMENTS)) + (
             infile
         )
         return self.execute_command(command, cwd=dirname(infile))

--- a/pipeline/compilers/stylus.py
+++ b/pipeline/compilers/stylus.py
@@ -1,7 +1,5 @@
 from __future__ import unicode_literals
 
-import shlex
-
 from pipeline.conf import settings
 from os.path import dirname
 
@@ -18,7 +16,7 @@ class StylusCompiler(SubProcessCompiler):
     def compile_file(self, infile, outfile, outdated=False, force=False):
         command = (
             settings.PIPELINE_STYLUS_BINARY,
-        ) + tuple(shlex.split(settings.PIPELINE_STYLUS_ARGUMENTS)) + (
+            settings.PIPELINE_STYLUS_ARGUMENTS,
             infile
         )
         return self.execute_command(command, cwd=dirname(infile))

--- a/pipeline/conf.py
+++ b/pipeline/conf.py
@@ -95,7 +95,7 @@ class PipelineSettings(object):
             raise AttributeError("'%s' setting not found" % name)
 
         if name.startswith("PIPELINE_") and name.endswith(("_BINARY", "_ARGUMENTS")):
-            if isinstance(value, str):
+            if isinstance(value, (type(u""), type(b""))):
                 return tuple(shlex.split(value))
             return tuple(value)
 

--- a/pipeline/conf.py
+++ b/pipeline/conf.py
@@ -82,14 +82,15 @@ class PipelineSettings(object):
     '''
     Lazy Django settings wrapper for Django Pipeline
     '''
-    def __init__(self, wrapped_settings):
+    def __init__(self, wrapped_settings, DEFAULTS=DEFAULTS):
         self.wrapped_settings = wrapped_settings
+        self.DEFAULTS = DEFAULTS
 
     def __getattr__(self, name):
         if hasattr(self.wrapped_settings, name):
             value = getattr(self.wrapped_settings, name)
-        elif name in DEFAULTS:
-            value = DEFAULTS[name]
+        elif name in self.DEFAULTS:
+            value = self.DEFAULTS[name]
         else:
             raise AttributeError("'%s' setting not found" % name)
 

--- a/pipeline/conf.py
+++ b/pipeline/conf.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import shlex
+
 from django.conf import settings as _settings
 
 DEFAULTS = {
@@ -85,10 +87,17 @@ class PipelineSettings(object):
 
     def __getattr__(self, name):
         if hasattr(self.wrapped_settings, name):
-            return getattr(self.wrapped_settings, name)
+            value = getattr(self.wrapped_settings, name)
         elif name in DEFAULTS:
-            return DEFAULTS[name]
+            value = DEFAULTS[name]
         else:
             raise AttributeError("'%s' setting not found" % name)
+
+        if name.startswith("PIPELINE_") and name.endswith(("_BINARY", "_ARGUMENTS")):
+            if isinstance(value, str):
+                return tuple(shlex.split(value))
+            return tuple(value)
+
+        return value
 
 settings = PipelineSettings(_settings)

--- a/tests/tests/test_compiler.py
+++ b/tests/tests/test_compiler.py
@@ -1,13 +1,68 @@
 from __future__ import unicode_literals
 
+import os
+
 from django.test import TestCase
 
 from pipeline.conf import settings
-from pipeline.compilers import Compiler, CompilerBase
+from pipeline.compilers import Compiler, CompilerBase, SubProcessCompiler
 from pipeline.collector import default_collector
-
+from pipeline.exceptions import CompilerError
 
 from tests.utils import _
+
+
+class FailingCompiler(SubProcessCompiler):
+    output_extension = 'junk'
+
+    def match_file(self, path):
+        return path.endswith('.coffee')
+
+    def compile_file(self, infile, outfile, outdated=False, force=False):
+        command = (("/usr/bin/env", "false",),)
+        return self.execute_command(command)
+
+
+class InvalidCompiler(SubProcessCompiler):
+    output_extension = 'junk'
+
+    def match_file(self, path):
+        return path.endswith('.coffee')
+
+    def compile_file(self, infile, outfile, outdated=False, force=False):
+        command = (
+            ("this-exists-nowhere-as-a-command-and-should-fail",),
+            infile,
+            outfile
+        )
+        return self.execute_command(command)
+
+
+class CopyingCompiler(SubProcessCompiler):
+    output_extension = 'junk'
+
+    def match_file(self, path):
+        return path.endswith('.coffee')
+
+    def compile_file(self, infile, outfile, outdated=False, force=False):
+        command = (
+            ("cp",),
+            ("--no-dereference", "--preserve=links",),
+            infile,
+            outfile
+        )
+        return self.execute_command(command)
+
+
+class LineNumberingCompiler(SubProcessCompiler):
+    output_extension = 'junk'
+
+    def match_file(self, path):
+        return path.endswith('.coffee')
+
+    def compile_file(self, infile, outfile, outdated=False, force=False):
+        command = (("/usr/bin/env", "cat"), ("-n",), infile,)
+        return self.execute_command(command, stdout_captured=outfile)
 
 
 class DummyCompiler(CompilerBase):
@@ -20,7 +75,7 @@ class DummyCompiler(CompilerBase):
         return
 
 
-class CompilerTest(TestCase):
+class DummyCompilerTest(TestCase):
     def setUp(self):
         default_collector.collect()
         self.compiler = Compiler()
@@ -41,6 +96,75 @@ class CompilerTest(TestCase):
             _('pipeline/js/application.js'),
         ])
         self.assertEqual([_('pipeline/js/dummy.js'), _('pipeline/js/application.js')], list(paths))
+
+    def tearDown(self):
+        default_collector.clear()
+        settings.PIPELINE_COMPILERS = self.old_compilers
+
+class CompilerStdoutTest(TestCase):
+    def setUp(self):
+        default_collector.collect()
+        self.compiler = Compiler()
+        self.old_compilers = settings.PIPELINE_COMPILERS
+        settings.PIPELINE_COMPILERS = ['tests.tests.test_compiler.LineNumberingCompiler']
+
+    def test_output_path(self):
+        output_path = self.compiler.output_path("js/helpers.coffee", "js")
+        self.assertEqual(output_path, "js/helpers.js")
+
+    def test_compile(self):
+        paths = self.compiler.compile([_('pipeline/js/dummy.coffee'),])
+        self.assertEqual([_('pipeline/js/dummy.junk'),], list(paths))
+
+    def tearDown(self):
+        default_collector.clear()
+        settings.PIPELINE_COMPILERS = self.old_compilers
+
+class CompilerSelfWriterTest(TestCase):
+    def setUp(self):
+        default_collector.collect()
+        self.compiler = Compiler()
+        self.old_compilers = settings.PIPELINE_COMPILERS
+        settings.PIPELINE_COMPILERS = ['tests.tests.test_compiler.CopyingCompiler']
+
+    def test_output_path(self):
+        output_path = self.compiler.output_path("js/helpers.coffee", "js")
+        self.assertEqual(output_path, "js/helpers.js")
+
+    def test_compile(self):
+        paths = self.compiler.compile([_('pipeline/js/dummy.coffee'),])
+        default_collector.collect()
+        self.assertEqual([_('pipeline/js/dummy.junk'),], list(paths))
+
+    def tearDown(self):
+        default_collector.clear()
+        settings.PIPELINE_COMPILERS = self.old_compilers
+
+class InvalidCompilerTest(TestCase):
+    def setUp(self):
+        default_collector.collect()
+        self.compiler = Compiler()
+        self.old_compilers = settings.PIPELINE_COMPILERS
+        settings.PIPELINE_COMPILERS = ['tests.tests.test_compiler.InvalidCompiler']
+
+    def test_compile(self):
+        self.assertRaises(CompilerError,
+                self.compiler.compile, [_('pipeline/js/dummy.coffee'),])
+
+    def tearDown(self):
+        default_collector.clear()
+        settings.PIPELINE_COMPILERS = self.old_compilers
+
+class FailingCompilerTest(TestCase):
+    def setUp(self):
+        default_collector.collect()
+        self.compiler = Compiler()
+        self.old_compilers = settings.PIPELINE_COMPILERS
+        settings.PIPELINE_COMPILERS = ['tests.tests.test_compiler.FailingCompiler']
+
+    def test_compile(self):
+        self.assertRaises(CompilerError,
+                self.compiler.compile, [_('pipeline/js/dummy.coffee'),])
 
     def tearDown(self):
         default_collector.clear()

--- a/tests/tests/test_conf.py
+++ b/tests/tests/test_conf.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.test import TestCase
+
+from pipeline.conf import PipelineSettings
+
+class TestSettings(TestCase):
+
+    def test_3unicode(self):
+        s = PipelineSettings(dict(), DEFAULTS={ "PIPELINE_FOO_BINARY": "env actualprogram" })
+        self.assertEqual(s.PIPELINE_FOO_BINARY, ('env', 'actualprogram'))
+
+    def test_2unicode(self):
+        s = PipelineSettings(dict(), DEFAULTS={ "PIPELINE_FOO_BINARY": u"env actualprogram" })
+        self.assertEqual(s.PIPELINE_FOO_BINARY, ('env', 'actualprogram'))
+
+    def test_2bytes(self):
+        s = PipelineSettings(dict(), DEFAULTS={ "PIPELINE_FOO_BINARY": "env actualprogram" })
+        self.assertEqual(s.PIPELINE_FOO_BINARY, ('env', 'actualprogram'))
+
+    def test_expected_splitting(self):
+        s = PipelineSettings(dict(), DEFAULTS={ "PIPELINE_FOO_BINARY": "env actualprogram" })
+        self.assertEqual(s.PIPELINE_FOO_BINARY, ('env', 'actualprogram'))
+
+    def test_expected_preservation(self):
+        s = PipelineSettings(dict(), DEFAULTS={ "PIPELINE_FOO_BINARY": r"actual\ program" })
+        self.assertEqual(s.PIPELINE_FOO_BINARY, ('actual program',))
+
+    def test_tuples_are_normal(self):
+        s = PipelineSettings(dict(), DEFAULTS={ "PIPELINE_FOO_ARGUMENTS": ("explicit", "with", "args") })
+        self.assertEqual(s.PIPELINE_FOO_ARGUMENTS, ('explicit', 'with', 'args'))


### PR DESCRIPTION
Names on disk and config files should not have to be safe for shells to
interpret. As close to possible, we should take literals and give literals to
the OS kernel to operate on directly. For filename globs, it is our
responsiblility to expand them, and if we had no problem with backwards
compatibility, we would insist config files' SCRIPT_ARGUMENTS parameters are
tuples of discrete values. Delegating those to a shell breaks clear boundaries
of interpreetation and will always be prone to errors, oversight, and
incompatibility.

So, now, we never take names that are unsafe and try to make then safe for a
shell, because we don't need a shell.

This fixes #444, which had problems with Windows paths being insensible to the
crazy quoting we hoped would make a filename safe for a shell.

This fixes #494, which had a compiler-attempt stdout captured as part of a
string interpreted by a shell. When the compiler didn't exist, that shell
expression STILL created empty files, and the pipeline thenafter served an
empty file as if it were real compiler output.