### PR TITLE
Don't mix django templates and jinja2

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -96,7 +96,7 @@ You just need to pass ``pipeline.templatetags.ext.PipelineExtension`` to your Ji
         'APP_DIRS': True,
         'OPTIONS': {
             'environment': 'myproject.jinja2.environment',
-            'extensions': ['pipeline.templatetags.ext.PipelineExtension']
+            'extensions': ['pipeline.jinja2.PipelineExtension']
         }
     }
 

--- a/pipeline/jinja2/__init__.py
+++ b/pipeline/jinja2/__init__.py
@@ -7,7 +7,7 @@ from django.contrib.staticfiles.storage import staticfiles_storage
 
 from ..packager import PackageNotFound
 from ..utils import guess_type
-from .pipeline import PipelineMixin
+from ..templatetags.pipeline import PipelineMixin
 
 
 class PipelineExtension(PipelineMixin, Extension):

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -56,10 +56,6 @@ STATICFILES_FINDERS = (
 
 SECRET_KEY = "django-pipeline"
 
-TEMPLATE_DIRS = (
-    local_path('templates'),
-)
-
 PIPELINE = {
     'STYLESHEETS': {
         'screen': {
@@ -122,6 +118,11 @@ PIPELINE = {
 }
 
 
+TEMPLATE_DIRS = (
+    local_path('templates'),
+)
+
+
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
@@ -132,5 +133,8 @@ TEMPLATES = [
         'BACKEND': 'django.template.backends.jinja2.Jinja2',
         'APP_DIRS': True,
         'DIRS': TEMPLATE_DIRS,
+        'OPTIONS': {
+            'extensions': ['pipeline.jinja2.PipelineExtension']
+        }
     }
 ]

--- a/tests/tests/test_template.py
+++ b/tests/tests/test_template.py
@@ -6,7 +6,7 @@ from jinja2 import Environment, PackageLoader
 from django.template import Template, Context
 from django.test import TestCase
 
-from pipeline.templatetags.ext import PipelineExtension
+from pipeline.jinja2 import PipelineExtension
 
 from tests.utils import pipeline_settings
 


### PR DESCRIPTION
Separate django templates code from jinja2 code to avoid surprises when jinja2 is not present.

This will fix #478 #510.