### PR TITLE
Fix literal markup for settings

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -143,7 +143,7 @@ Other settings
 
   Defaults to ``'pipeline.compressors.yuglify.YuglifyCompressor'``.
 
-JS_COMPRESSOR``
+``JS_COMPRESSOR``
 ...........................
 
   Compressor class to be applied to JavaScript files.
@@ -156,7 +156,7 @@ JS_COMPRESSOR``
 
   Please note that in order to use Yuglify compressor, you need to install Yuglify (see :doc:`installation` for more details).
 
-TEMPLATE_NAMESPACE``
+``TEMPLATE_NAMESPACE``
 ...............................
 
   Object name where all of your compiled templates will be added, from within your browser.
@@ -165,7 +165,7 @@ TEMPLATE_NAMESPACE``
   Defaults to ``"window.JST"``
 
 
-TEMPLATE_EXT``
+``TEMPLATE_EXT``
 .........................
 
   The extension for which Pipeline will consider the file as a Javascript template.
@@ -173,7 +173,7 @@ TEMPLATE_EXT``
 
   Defaults to ``".jst"``
 
-TEMPLATE_FUNC``
+``TEMPLATE_FUNC``
 ..........................
 
   JavaScript function that compiles your JavaScript templates.
@@ -183,7 +183,7 @@ TEMPLATE_FUNC``
 
   Defaults to ``"_.template"``
 
-TEMPLATE_SEPARATOR``
+``TEMPLATE_SEPARATOR``
 ...............................
 
   Character chain used by Pipeline as replacement for directory separator.
@@ -191,7 +191,7 @@ TEMPLATE_SEPARATOR``
   Defaults to ``"_"``
 
 
-MIMETYPES``
+``MIMETYPES``
 ......................
 
   Tuple that match file extension with their corresponding mimetypes.
@@ -241,7 +241,7 @@ Overriding embedding settings
 
 You can override these rules using the following settings:
 
-EMBED_MAX_IMAGE_SIZE``
+``EMBED_MAX_IMAGE_SIZE``
 .................................
 
   Setting that controls the maximum image size (in bytes) to embed in CSS using Data-URIs.
@@ -249,7 +249,7 @@ EMBED_MAX_IMAGE_SIZE``
 
   Defaults to ``32700``
 
-EMBED_PATH``
+``EMBED_PATH``
 .......................
 
   Setting the directory that an asset needs to be in so that it is embedded
@@ -275,4 +275,4 @@ All javascript output is wrapped in an anonymous function : ::
 
 This safety wrapper, make it difficult to pollute the global namespace by accident and improve performance.
 
-You can override this behavior by setting DISABLE_WRAPPER`` to ``True``.
+You can override this behavior by setting ``DISABLE_WRAPPER`` to ``True``.


### PR DESCRIPTION
In headings and one non-heading. This is probably a leftover after some semi-automated way of removing that `PIPELINE_` prefix.