### PR TITLE
Changed and transformed command string in Compressors to list with ar…

### DIFF
--- a/pipeline/compilers/__init__.py
+++ b/pipeline/compilers/__init__.py
@@ -14,11 +14,10 @@ from django.contrib.staticfiles import finders
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.core.files.base import ContentFile
 from django.utils.encoding import smart_bytes
-from django.utils.six import string_types
 
 from pipeline.conf import settings
 from pipeline.exceptions import CompilerError
-from pipeline.utils import to_class
+from pipeline.utils import to_class, command_as_flat_list
 
 
 class Compiler(object):
@@ -104,18 +103,8 @@ class SubProcessCompiler(CompilerBase):
         spaces or crazy characters) and OS agnostic (existing and future OSes
         that Python supports should already work).
 
-        The only thing weird here is that any incoming command arg item may
-        itself be a tuple. This allows compiler implementations to look clean
-        while supporting historical string config settings and maintaining
-        backwards compatibility. Thus, we flatten one layer deep.
-         ((env, foocomp), infile, (-arg,)) -> (env, foocomp, infile, -arg)
         """
-        argument_list = []
-        for flattening_arg in command:
-            if isinstance(flattening_arg, string_types):
-                argument_list.append(flattening_arg)
-            else:
-                argument_list.extend(flattening_arg)
+        argument_list = command_as_flat_list(command)
 
         try:
             # We always catch stdout in a file, but we may not have a use for it.

--- a/pipeline/compressors/__init__.py
+++ b/pipeline/compressors/__init__.py
@@ -11,7 +11,7 @@ from django.contrib.staticfiles.storage import staticfiles_storage
 from django.utils.encoding import smart_bytes, force_text
 
 from pipeline.conf import settings
-from pipeline.utils import to_class, relpath
+from pipeline.utils import to_class, relpath, command_as_flat_list
 from pipeline.exceptions import CompressorError
 
 URL_DETECTOR = r"""url\((['"]){0,1}\s*(.*?)["']{0,1}\)"""
@@ -235,8 +235,9 @@ class CompressorBase(object):
 class SubProcessCompressor(CompressorBase):
     def execute_command(self, command, content):
         import subprocess
-        pipe = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE,
-                                stdin=subprocess.PIPE, stderr=subprocess.PIPE)
+        pipe = subprocess.Popen(command_as_flat_list(command), shell=True,
+                                stdout=subprocess.PIPE, stdin=subprocess.PIPE,
+                                stderr=subprocess.PIPE)
         if content:
             content = smart_bytes(content)
         stdout, stderr = pipe.communicate(content)

--- a/pipeline/compressors/closure.py
+++ b/pipeline/compressors/closure.py
@@ -6,5 +6,8 @@ from pipeline.compressors import SubProcessCompressor
 
 class ClosureCompressor(SubProcessCompressor):
     def compress_js(self, js):
-        command = '%s %s' % (settings.CLOSURE_BINARY, settings.CLOSURE_ARGUMENTS)
+        command = (
+            settings.CLOSURE_BINARY,
+            settings.CLOSURE_ARGUMENTS
+        )
         return self.execute_command(command, js)

--- a/pipeline/compressors/cssmin.py
+++ b/pipeline/compressors/cssmin.py
@@ -6,5 +6,8 @@ from pipeline.compressors import SubProcessCompressor
 
 class CSSMinCompressor(SubProcessCompressor):
     def compress_css(self, css):
-        command = "%s %s" % (settings.CSSMIN_BINARY, settings.CSSMIN_ARGUMENTS)
+        command = (
+            settings.CSSMIN_BINARY,
+            settings.CSSMIN_ARGUMENTS
+        )
         return self.execute_command(command, css)

--- a/pipeline/compressors/csstidy.py
+++ b/pipeline/compressors/csstidy.py
@@ -10,8 +10,9 @@ class CSSTidyCompressor(SubProcessCompressor):
     def compress_css(self, css):
         output_file = tempfile.NamedTemporaryFile(suffix='.pipeline')
 
-        command = '%s - %s %s' % (
+        command = (
             settings.CSSTIDY_BINARY,
+            '-',
             settings.CSSTIDY_ARGUMENTS,
             output_file.name
         )

--- a/pipeline/compressors/uglifyjs.py
+++ b/pipeline/compressors/uglifyjs.py
@@ -6,7 +6,10 @@ from pipeline.compressors import SubProcessCompressor
 
 class UglifyJSCompressor(SubProcessCompressor):
     def compress_js(self, js):
-        command = '%s %s' % (settings.UGLIFYJS_BINARY, settings.UGLIFYJS_ARGUMENTS)
+        command = [
+            settings.UGLIFYJS_BINARY,
+            settings.UGLIFYJS_ARGUMENTS
+        ]
         if self.verbose:
-            command += ' --verbose'
+            command.append('--verbose')
         return self.execute_command(command, js)

--- a/pipeline/compressors/yuglify.py
+++ b/pipeline/compressors/yuglify.py
@@ -6,7 +6,11 @@ from pipeline.compressors import SubProcessCompressor
 
 class YuglifyCompressor(SubProcessCompressor):
     def compress_common(self, content, compress_type, arguments):
-        command = '%s --type=%s %s' % (settings.YUGLIFY_BINARY, compress_type, arguments)
+        command = (
+            settings.YUGLIFY_BINARY,
+            '--type={}'.format(compress_type),
+            arguments
+        )
         return self.execute_command(command, content)
 
     def compress_js(self, js):

--- a/pipeline/compressors/yui.py
+++ b/pipeline/compressors/yui.py
@@ -6,7 +6,11 @@ from pipeline.compressors import SubProcessCompressor
 
 class YUICompressor(SubProcessCompressor):
     def compress_common(self, content, compress_type, arguments):
-        command = '%s --type=%s %s' % (settings.YUI_BINARY, compress_type, arguments)
+        command = (
+            settings.YUI_BINARY,
+            '--type={}'.format(compress_type),
+            arguments
+        )
         return self.execute_command(command, content)
 
     def compress_js(self, js):

--- a/pipeline/utils.py
+++ b/pipeline/utils.py
@@ -10,6 +10,7 @@ except ImportError:
     from urllib import quote
 
 from django.utils.encoding import smart_text
+from django.utils.six import string_types
 
 from pipeline.conf import settings
 
@@ -54,3 +55,21 @@ def relpath(path, start=posixpath.curdir):
     if not rel_list:
         return posixpath.curdir
     return posixpath.join(*rel_list)
+
+
+def command_as_flat_list(command):
+    """Returns transformed command with nested lists as flat list.
+    For example:
+        ((env, foocomp), infile, (-arg,)) -> (env, foocomp, infile, -arg)
+    """
+    if isinstance(command, string_types):
+        return [command]
+
+    argument_list = []
+    for flattening_arg in command:
+        if isinstance(flattening_arg, string_types):
+            argument_list.append(flattening_arg)
+        else:
+            argument_list.extend(flattening_arg)
+
+    return argument_list

--- a/tests/tests/test_compressor.py
+++ b/tests/tests/test_compressor.py
@@ -173,7 +173,7 @@ class CompressorTest(TestCase):
     def test_compressor_subprocess_unicode(self):
         tests_path = os.path.dirname(os.path.dirname(__file__))
         output = SubProcessCompressor(False).execute_command(
-            '/usr/bin/env cat',
+            ['/usr/bin/env cat'],
             io.open(tests_path + '/assets/css/unicode.css', encoding="utf-8").read())
         self.assertEqual(""".some_class {
   // Some unicode

--- a/tests/tests/test_compressor.py
+++ b/tests/tests/test_compressor.py
@@ -12,8 +12,11 @@ except ImportError:
 
 from django.test import TestCase
 
-from pipeline.compressors import Compressor, TEMPLATE_FUNC, \
+from pipeline.compressors import (
+    Compressor,
+    TEMPLATE_FUNC,
     SubProcessCompressor
+)
 from pipeline.compressors.yuglify import YuglifyCompressor
 from pipeline.collector import default_collector
 
@@ -74,32 +77,32 @@ class CompressorTest(TestCase):
         self.assertEqual(base_path, _('js/templates'))
 
     def test_absolute_path(self):
-        absolute_path = self.compressor.absolute_path('../../images/sprite.png',
-            'css/plugins/')
+        absolute_path = self.compressor.absolute_path(
+            '../../images/sprite.png', 'css/plugins/')
         self.assertEqual(absolute_path, 'images/sprite.png')
         absolute_path = self.compressor.absolute_path('/images/sprite.png',
-            'css/plugins/')
+                                                      'css/plugins/')
         self.assertEqual(absolute_path, '/images/sprite.png')
 
     def test_template_name(self):
         name = self.compressor.template_name('templates/photo/detail.jst',
-            'templates/')
+                                             'templates/')
         self.assertEqual(name, 'photo_detail')
         name = self.compressor.template_name('templates/photo_edit.jst', '')
         self.assertEqual(name, 'photo_edit')
         name = self.compressor.template_name('templates\photo\detail.jst',
-            'templates\\')
+                                             'templates\\')
         self.assertEqual(name, 'photo_detail')
 
     @pipeline_settings(TEMPLATE_SEPARATOR='/')
     def test_template_name_separator(self):
         name = self.compressor.template_name('templates/photo/detail.jst',
-            'templates/')
+                                             'templates/')
         self.assertEqual(name, 'photo/detail')
         name = self.compressor.template_name('templates/photo_edit.jst', '')
         self.assertEqual(name, 'photo_edit')
         name = self.compressor.template_name('templates\photo\detail.jst',
-            'templates\\')
+                                             'templates\\')
         self.assertEqual(name, 'photo/detail')
 
     def test_compile_templates(self):
@@ -118,11 +121,12 @@ class CompressorTest(TestCase):
         self.assertFalse(self.compressor.embeddable(_('pipeline/images/arrow.dat'), 'datauri'))
 
     def test_construct_asset_path(self):
-        asset_path = self.compressor.construct_asset_path("../../images/sprite.png",
-            "css/plugins/gallery.css", "css/gallery.css")
+        asset_path = self.compressor.construct_asset_path(
+            "../../images/sprite.png", "css/plugins/gallery.css",
+            "css/gallery.css")
         self.assertEqual(asset_path, "../images/sprite.png")
-        asset_path = self.compressor.construct_asset_path("/images/sprite.png",
-            "css/plugins/gallery.css", "css/gallery.css")
+        asset_path = self.compressor.construct_asset_path(
+            "/images/sprite.png", "css/plugins/gallery.css", "css/gallery.css")
         self.assertEqual(asset_path, "/images/sprite.png")
 
     def test_url_rewrite(self):

--- a/tests/tests/test_utils.py
+++ b/tests/tests/test_utils.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 from django.test import TestCase
 
-from pipeline.utils import guess_type
+from pipeline.utils import guess_type, command_as_flat_list
 
 
 class UtilTest(TestCase):
@@ -11,3 +11,19 @@ class UtilTest(TestCase):
         self.assertEqual('text/css', guess_type('stylesheet.css'))
         self.assertEqual('text/coffeescript', guess_type('application.coffee'))
         self.assertEqual('text/less', guess_type('stylesheet.less'))
+
+
+class FlatCommandAsListTest(TestCase):
+
+    def test_command_as_string(self):
+        command = 'foo bar'
+        self.assertEqual(['foo bar'], command_as_flat_list(command))
+
+    def test_command_as_list_of_string(self):
+        command = ('foo', 'bar')
+        self.assertEqual(['foo', 'bar'], command_as_flat_list(command))
+
+    def test_command_as_list_with_nested_lists(self):
+        command = ('foo', ('fiz', 'baz',), 'bar')
+        self.assertEqual(['foo', 'fiz', 'baz', 'bar'],
+                         command_as_flat_list(command))


### PR DESCRIPTION
Changed and transformed command string in Compressors to list with arguments.

After merge this PR: https://github.com/jazzband/django-pipeline/pull/519 some settings are automatically convereted from string to tuple: https://github.com/jazzband/django-pipeline/pull/519/files#diff-c603f83486e60bf60f35fbd43bc70cf4R98

For example we had commands in Compressors like this **string**: `"('/env/bin/env', 'foo') bar ('--example',)"`.