### PR TITLE
Add note about supported Django versions

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -79,3 +79,11 @@ Yuglify wraps UglifyJS and cssmin, applying the default YUI configurations to th
 It can be downloaded from: https://github.com/yui/yuglify/.
 
 If you do not install yuglify, make sure to disable the compressor in your settings.
+
+Supported Django versions
+=========================
+
+Following versions of Django are supported:
+
+- 1.8.*
+- 1.9.*


### PR DESCRIPTION
Be explicit about which Django versions django-pipeline supports (https://github.com/jazzband/django-pipeline/commit/148271bd86126913d85ebff187c4faa957bf88d2 silently broke support for older versions)