### PR TITLE
Add --include-path argument to less compiler.

### DIFF
--- a/pipeline/compilers/less.py
+++ b/pipeline/compilers/less.py
@@ -1,9 +1,24 @@
 from __future__ import unicode_literals
 
-from os.path import dirname
+import os
+
+from django.apps import apps
+from django.conf import settings as django_settings
 
 from pipeline.conf import settings
 from pipeline.compilers import SubProcessCompiler
+
+
+def _static_paths():
+    """Captures all the static direcoties, both from filesystem and apps.
+
+    """
+    for path in django_settings.STATICFILES_DIRS:
+        yield path
+    for app_config in apps.get_app_configs():
+        path = os.path.join(app_config.path, 'static')
+        if os.path.isdir(path):
+            yield path
 
 
 class LessCompiler(SubProcessCompiler):
@@ -14,9 +29,11 @@ class LessCompiler(SubProcessCompiler):
 
     def compile_file(self, infile, outfile, outdated=False, force=False):
         # Pipe to file rather than provide outfile arg due to a bug in lessc
+        include_path = '--include-path=%s' % os.pathsep.join(_static_paths())
         command = (
             settings.LESS_BINARY,
+            include_path,
             settings.LESS_ARGUMENTS,
             infile,
         )
-        return self.execute_command(command, cwd=dirname(infile), stdout_captured=outfile)
+        return self.execute_command(command, cwd=os.path.dirname(infile), stdout_captured=outfile)


### PR DESCRIPTION
Allows compiling less files with include statements across different
apps.
