### PR TITLE
Fix compatibility with Django < 1.8

### DIFF
--- a/pipeline/conf.py
+++ b/pipeline/conf.py
@@ -5,7 +5,11 @@ import collections
 import shlex
 
 from django.conf import settings as _settings
-from django.core.signals import setting_changed
+try:
+    from django.core.signals import setting_changed
+except ImportError:
+    # Django < 1.8
+    from django.test.signals import setting_changed
 from django.dispatch import receiver
 from django.utils.six import string_types
 


### PR DESCRIPTION
The 1.6.1 release added a dependency on the `setting_changed` signal. In Django
releases prior to 1.8, this signal is located in the `django.test.signals`
module, and in 1.8, an alias was added in `django.core.signals`.

This change adds a fallback import to restore compatibility with older versions
for applications which cannot (yet) migrate to the newer Djangos. It has been
tested against Django 1.6.11 and 1.8.9.