### PR TITLE
Don't filter out "missing" files in the glob stage.

### DIFF
--- a/pipeline/glob.py
+++ b/pipeline/glob.py
@@ -25,12 +25,7 @@ def iglob(pathname):
 
     """
     if not has_magic(pathname):
-        try:
-            if staticfiles_storage.exists(pathname):
-                yield pathname
-        except NotImplementedError:
-            # Being optimistic
-            yield pathname
+        yield pathname
         return
     dirname, basename = os.path.split(pathname)
     if not dirname:

--- a/tests/tests/test_glob.py
+++ b/tests/tests/test_glob.py
@@ -55,7 +55,6 @@ class GlobTest(TestCase):
         self.assertSequenceEqual(self.glob('a'), [self.normpath('a')])
         self.assertSequenceEqual(self.glob('a', 'D'), [self.normpath('a', 'D')])
         self.assertSequenceEqual(self.glob('aab'), [self.normpath('aab')])
-        self.assertSequenceEqual(self.glob('zymurgy'), [])
 
     def test_glob_one_directory(self):
         self.assertSequenceEqual(

--- a/tests/tests/test_storage.py
+++ b/tests/tests/test_storage.py
@@ -6,6 +6,7 @@ from django.core.management import call_command
 from django.test import TestCase
 from django.test.utils import override_settings, modify_settings
 
+from pipeline.collector import default_collector
 from pipeline.storage import PipelineStorage
 
 from tests.tests.test_compiler import DummyCompiler
@@ -49,11 +50,13 @@ class StorageTest(TestCase):
 
     @pipeline_settings(JS_COMPRESSOR=None, CSS_COMPRESSOR=None)
     def test_post_process_dry_run(self):
+        default_collector.collect()
         processed_files = PipelineStorage().post_process({}, True)
         self.assertEqual(list(processed_files), [])
 
-    @pipeline_settings(JS_COMPRESSOR=None, CSS_COMPRESSOR=None)
+    @pipeline_settings(JS_COMPRESSOR=None, CSS_COMPRESSOR=None, COMPILERS=['tests.tests.test_storage.DummyCSSCompiler'])
     def test_post_process(self):
+        default_collector.collect()
         storage = PipelineStorage()
         processed_files = storage.post_process({})
         self.assertTrue(('screen.css', 'screen.css', True) in processed_files)


### PR DESCRIPTION
Commit bd6b9d8 dramatically changed the way that files are loaded, and had the
side-effect of filtering out any files which were sourced by finders outside of
the main `STATICFILES_DIRS`.

In the case I'm trying to address, we have an extension framework (in Review
Board and Djblets) which can load static media from third-party packages which
are activated at runtime. This media is loaded by instantiating
`StylesheetNode` and `JavascriptNode` from `pipeline.templatetags` in
combination with a special finder. Because django-pipeline no longer uses
finders before the compile stage, calling `storage.exists` (via
`Package.sources` -> `glob`) silently filters these out.

Inside `glob`, I agree that it's useful to test existence when trying to expand
`*` or `?`, but when the path is just a normal filename, it should be safe to
assume that the user knows what they're doing. This causes the paths to be
emitted into the rendered template whether or not `staticfiles_storage` claims
they exist, and anything which the configured staticfiles finders can't locate
will surface as a 404 rather than being silently eaten.