### PR TITLE
Allow compilers to override output_path.

### DIFF
--- a/pipeline/compilers/__init__.py
+++ b/pipeline/compilers/__init__.py
@@ -31,12 +31,12 @@ class Compiler(object):
             for compiler in self.compilers:
                 compiler = compiler(verbose=self.verbose, storage=self.storage)
                 if compiler.match_file(input_path):
-                    output_path = self.output_path(input_path, compiler.output_extension)
+                    output_path = compiler.output_path(input_path, compiler.output_extension)
                     try:
                         infile = self.storage.path(input_path)
                     except NotImplementedError:
                         infile = finders.find(input_path)
-                    outfile = self.output_path(infile, compiler.output_extension)
+                    outfile = compiler.output_path(infile, compiler.output_extension)
                     outdated = compiler.is_outdated(input_path, output_path)
                     compiler.compile_file(infile, outfile,
                                           outdated=outdated, force=force)
@@ -52,10 +52,6 @@ class Compiler(object):
         else:
             with futures.ThreadPoolExecutor(max_workers=multiprocessing.cpu_count()) as executor:
                 return list(executor.map(_compile, paths))
-
-    def output_path(self, path, extension):
-        path = os.path.splitext(path)
-        return '.'.join((path[0], extension))
 
 
 class CompilerBase(object):
@@ -77,6 +73,10 @@ class CompilerBase(object):
         content = file.read()
         file.close()
         return content
+
+    def output_path(self, path, extension):
+        path = os.path.splitext(path)
+        return '.'.join((path[0], extension))
 
     def is_outdated(self, infile, outfile):
         if not self.storage.exists(outfile):

--- a/tests/tests/test_compiler.py
+++ b/tests/tests/test_compiler.py
@@ -81,7 +81,9 @@ class DummyCompilerTest(TestCase):
         self.compiler = Compiler()
 
     def test_output_path(self):
-        output_path = self.compiler.output_path("js/helpers.coffee", "js")
+        compiler_class = self.compiler.compilers[0]
+        compiler = compiler_class(verbose=self.compiler.verbose, storage=self.compiler.storage)
+        output_path = compiler.output_path("js/helpers.coffee", "js")
         self.assertEqual(output_path, "js/helpers.js")
 
     def test_compilers_class(self):
@@ -107,7 +109,9 @@ class CompilerStdoutTest(TestCase):
         self.compiler = Compiler()
 
     def test_output_path(self):
-        output_path = self.compiler.output_path("js/helpers.coffee", "js")
+        compiler_class = self.compiler.compilers[0]
+        compiler = compiler_class(verbose=self.compiler.verbose, storage=self.compiler.storage)
+        output_path = compiler.output_path("js/helpers.coffee", "js")
         self.assertEqual(output_path, "js/helpers.js")
 
     def test_compile(self):
@@ -126,7 +130,9 @@ class CompilerSelfWriterTest(TestCase):
         self.compiler = Compiler()
 
     def test_output_path(self):
-        output_path = self.compiler.output_path("js/helpers.coffee", "js")
+        compiler_class = self.compiler.compilers[0]
+        compiler = compiler_class(verbose=self.compiler.verbose, storage=self.compiler.storage)
+        output_path = compiler.output_path("js/helpers.coffee", "js")
         self.assertEqual(output_path, "js/helpers.js")
 
     def test_compile(self):


### PR DESCRIPTION
The current logic for compilers to manipulate output paths is pretty simple,
using `os.path.splitext` and the compiler's `output_extension`. This precludes
doing fancier things by just implementing one's own compiler class.

This change moves the `output_file` method into the CompilerBase class, so that
subclasses can override its behavior to suit their own needs.