### PR TITLE
Fix an UnboundLocalError if a compiler fails.

### DIFF
--- a/pipeline/compilers/__init__.py
+++ b/pipeline/compilers/__init__.py
@@ -112,9 +112,12 @@ class SubProcessCompiler(CompilerBase):
                 argument_list.extend(flattening_arg)
 
         try:
+            stdout_name = None
+
             # We always catch stdout in a file, but we may not have a use for it.
             temp_file_container = cwd or os.path.dirname(stdout_captured or "") or os.getcwd()
             with NamedTemporaryFile(delete=False, dir=temp_file_container) as stdout:
+                stdout_name = stdout.name
                 compiling = subprocess.Popen(argument_list, cwd=cwd,
                                              stdout=stdout,
                                              stderr=subprocess.PIPE)
@@ -135,7 +138,8 @@ class SubProcessCompiler(CompilerBase):
             raise CompilerError(e)
         finally:
             # Decide what to do with captured stdout.
-            if stdout_captured:
-                os.rename(stdout.name, os.path.join(cwd or os.curdir, stdout_captured))
-            else:
-                os.remove(stdout.name)
+            if stdout_name:
+                if stdout_captured:
+                    os.rename(stdout_name, os.path.join(cwd or os.curdir, stdout_captured))
+                else:
+                    os.remove(stdout_name)

--- a/pipeline/compilers/__init__.py
+++ b/pipeline/compilers/__init__.py
@@ -111,13 +111,11 @@ class SubProcessCompiler(CompilerBase):
             else:
                 argument_list.extend(flattening_arg)
 
+        stdout = None
         try:
-            stdout_name = None
-
             # We always catch stdout in a file, but we may not have a use for it.
             temp_file_container = cwd or os.path.dirname(stdout_captured or "") or os.getcwd()
             with NamedTemporaryFile(delete=False, dir=temp_file_container) as stdout:
-                stdout_name = stdout.name
                 compiling = subprocess.Popen(argument_list, cwd=cwd,
                                              stdout=stdout,
                                              stderr=subprocess.PIPE)
@@ -138,8 +136,8 @@ class SubProcessCompiler(CompilerBase):
             raise CompilerError(e)
         finally:
             # Decide what to do with captured stdout.
-            if stdout_name:
+            if stdout:
                 if stdout_captured:
-                    os.rename(stdout_name, os.path.join(cwd or os.curdir, stdout_captured))
+                    os.rename(stdout.name, os.path.join(cwd or os.curdir, stdout_captured))
                 else:
-                    os.remove(stdout_name)
+                    os.remove(stdout.name)


### PR DESCRIPTION
Depending on where an exception is raised inside a compiler's
`execute_command`, the `stdout` variable may not be assigned. In this case, the
finally handler would fail with an `UnboundLocalError`, hiding the true cause
of the exception. This change adds a new variable, `stdout_name`, which is
populated once we've actually created the file. After this, the `CompilerError`
is successfully raised with the contents of the true error.