### PR TITLE
Fix paths given to compiler.is_outdated.

### DIFF
--- a/pipeline/compilers/__init__.py
+++ b/pipeline/compilers/__init__.py
@@ -31,16 +31,16 @@ class Compiler(object):
             for compiler in self.compilers:
                 compiler = compiler(verbose=self.verbose, storage=self.storage)
                 if compiler.match_file(input_path):
-                    output_path = self.output_path(input_path, compiler.output_extension)
                     try:
                         infile = self.storage.path(input_path)
                     except NotImplementedError:
                         infile = finders.find(input_path)
                     outfile = self.output_path(infile, compiler.output_extension)
-                    outdated = compiler.is_outdated(input_path, output_path)
+                    outdated = compiler.is_outdated(infile, outfile)
                     compiler.compile_file(infile, outfile,
                                           outdated=outdated, force=force)
-                    return output_path
+
+                    return self.output_path(input_path, compiler.output_extension)
             else:
                 return input_path
 


### PR DESCRIPTION
The check to see whether or not a source file is outdated was being passed the
`input_path` and `output_path` variables, which are not the actual paths to
files on disk. In particular, `input_path` is the path which will be searched
for using the staticfiles finders, and `output_path` is the relative path
within the staticfiles root. If the staticfiles root was not the same as the
root directory of the project, this would result in the check always reporting
that the file was outdated. In addition, if a source file required a finder to
locate, the check would fail.

Changing this to use `infile` and `outfile` instead means that the check
operates on the same file paths that the compiler will. This therefore checks
the files that were copied by the collector against the files which are
outputted by the compiler, which is a much more correct idea of whether
something is out of date.

This was tested in conjunction with a custom LessCompiler that uses a helper to
introspect dependencies. Before this change, that helper was seeing file paths
that did not exist (since STATIC_ROOT is a few subdirectories deep in our
codebase). Afterwards, it is able to successfully introspect all the source
files to build the dependency tree.