### PR TITLE
Add support for older Djangos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,12 @@ python:
   - 3.5
 sudo: false
 env:
+  - TOXENV=py27-django16
+  - TOXENV=py34-django16
+  - TOXENV=pypy-django16
+  - TOXENV=py27-django17
+  - TOXENV=py34-django17
+  - TOXENV=pypy-django17
   - TOXENV=py27-django18
   - TOXENV=pypy-django18
   - TOXENV=py34-django18

--- a/tests/tests/test_storage.py
+++ b/tests/tests/test_storage.py
@@ -4,7 +4,13 @@ from django.contrib.staticfiles import finders
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.core.management import call_command
 from django.test import TestCase
-from django.test.utils import override_settings, modify_settings
+from django.test.utils import override_settings
+
+try:
+    from django.test.utils import modify_settings
+except ImportError:
+    # Django < 1.7
+    from tests.utils import modify_settings
 
 from pipeline.collector import default_collector
 from pipeline.storage import PipelineStorage

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,13 @@
 import os
 
-from django.test import override_settings
+from django.conf import settings
+from django.utils import six
+
+try:
+    from django.test import override_settings
+except ImportError:
+    # Django < 1.7
+    from django.test.utils import override_settings
 
 
 def _(path):
@@ -11,3 +18,51 @@ def _(path):
 class pipeline_settings(override_settings):
     def __init__(self, **kwargs):
         self.options = {'PIPELINE': kwargs}
+
+
+# Django < 1.7 (copy-pasted from Django 1.7)
+class modify_settings(override_settings):
+    """
+    Like override_settings, but makes it possible to append, prepend or remove
+    items instead of redefining the entire list.
+    """
+    def __init__(self, *args, **kwargs):
+        if args:
+            # Hack used when instantiating from SimpleTestCase._pre_setup.
+            assert not kwargs
+            self.operations = args[0]
+        else:
+            assert not args
+            self.operations = list(kwargs.items())
+
+    def save_options(self, test_func):
+        if test_func._modified_settings is None:
+            test_func._modified_settings = self.operations
+        else:
+            # Duplicate list to prevent subclasses from altering their parent.
+            test_func._modified_settings = list(
+                test_func._modified_settings) + self.operations
+
+    def enable(self):
+        self.options = {}
+        for name, operations in self.operations:
+            try:
+                # When called from SimpleTestCase._pre_setup, values may be
+                # overridden several times; cumulate changes.
+                value = self.options[name]
+            except KeyError:
+                value = list(getattr(settings, name, []))
+            for action, items in operations.items():
+                # items my be a single value or an iterable.
+                if isinstance(items, six.string_types):
+                    items = [items]
+                if action == 'append':
+                    value = value + [item for item in items if item not in value]
+                elif action == 'prepend':
+                    value = [item for item in items if item not in value] + value
+                elif action == 'remove':
+                    value = [item for item in value if item not in items]
+                else:
+                    raise ValueError("Unsupported action: %s" % action)
+            self.options[name] = value
+        super(modify_settings, self).enable()

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    {py27,pypy,py34}-django{18,19},py35-django19,docs
+    {py27,pypy,py34}-django{16,17,18,19},py35-django19,docs
 
 [testenv]
 basepython =
@@ -11,6 +11,8 @@ basepython =
 deps =
   py{27,py}: mock
   py{27,py}: futures
+  django16: Django>=1.6,<1.7
+  django17: Django>=1.7,<1.8
   django18: Django>=1.8,<1.9
   django19: Django>=1.9,<1.10
   jinja2


### PR DESCRIPTION
Support for 1.7 is pretty effortless after #536.
Support for 1.6 is more tricky and involves adding a missing class (`modify_settings`).