### PR TITLE
Adds documentation regarding ES6 config

### DIFF
--- a/docs/compilers.rst
+++ b/docs/compilers.rst
@@ -159,7 +159,6 @@ To use it add this to your ``PIPELINE['COMPILERS']`` ::
   )
   
 
-
 ``BABEL_BINARY``
 --------------------------
 

--- a/docs/compilers.rst
+++ b/docs/compilers.rst
@@ -150,11 +150,14 @@ ES6 compiler
 The ES6 compiler uses `Babel <https://babeljs.io>`_
 to convert ES6+ code into vanilla ES5.
 
+Note that for files to be transpiled properly they must have the file extension **.es6**
+
 To use it add this to your ``PIPELINE['COMPILERS']`` ::
 
   PIPELINE['COMPILERS'] = (
       'pipeline.compilers.es6.ES6Compiler',
   )
+  
 
 
 ``BABEL_BINARY``


### PR DESCRIPTION
This adds one line to the ES6 compilers section, which notes that the `.es6` file extension is required. This was not immediately apparent to me, and the line would have saved some frustration.

fixes #550 