### PR TITLE
Add settings.VERBOSE

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -233,6 +233,12 @@ Defaults to ::
   If you support Internet Explorer version 8 and below, you should
   declare javascript files as ``text/javascript``.
 
+``VERBOSE``
+.............
+
+``True`` if Pipeline should print some extra information for debugging.
+
+Defaults to ``settings.DEBUG``.
 
 Embedding fonts and images
 ==========================

--- a/pipeline/conf.py
+++ b/pipeline/conf.py
@@ -24,6 +24,7 @@ DEFAULTS = {
     'PIPELINE_URL': _settings.STATIC_URL,
 
     'SHOW_ERRORS_INLINE': _settings.DEBUG,
+    'VERBOSE': _settings.DEBUG,
 
     'CSS_COMPRESSOR': 'pipeline.compressors.yuglify.YuglifyCompressor',
     'JS_COMPRESSOR': 'pipeline.compressors.yuglify.YuglifyCompressor',

--- a/pipeline/manifest.py
+++ b/pipeline/manifest.py
@@ -15,7 +15,7 @@ from pipeline.packager import Packager
 
 class PipelineManifest(Manifest):
     def __init__(self):
-        self.packager = Packager()
+        self.packager = Packager(verbose=settings.VERBOSE)
         self.packages = self.collect_packages()
         self.finders = get_finders()
         self.package_files = []

--- a/pipeline/storage.py
+++ b/pipeline/storage.py
@@ -9,6 +9,8 @@ from django.contrib.staticfiles.utils import matches_patterns
 
 from django.core.files.base import File
 
+from pipeline.conf import settings
+
 
 class PipelineMixin(object):
     packing = True
@@ -18,7 +20,7 @@ class PipelineMixin(object):
             return
 
         from pipeline.packager import Packager
-        packager = Packager(storage=self)
+        packager = Packager(storage=self, verbose=settings.VERBOSE)
         for package_name in packager.packages['css']:
             package = packager.package_for('css', package_name)
             output_file = package.output_filename

--- a/pipeline/templatetags/pipeline.py
+++ b/pipeline/templatetags/pipeline.py
@@ -41,8 +41,8 @@ class PipelineMixin(object):
             package = {package_name: package}
 
         packager = {
-            'js': Packager(css_packages={}, js_packages=package),
-            'css': Packager(css_packages=package, js_packages={}),
+            'js': Packager(css_packages={}, js_packages=package, verbose=settings.VERBOSE),
+            'css': Packager(css_packages=package, js_packages={}, verbose=settings.VERBOSE),
         }[package_type]
 
         return packager.package_for(package_type, package_name)
@@ -97,7 +97,7 @@ class PipelineMixin(object):
         if settings.PIPELINE_COLLECTOR_ENABLED:
             default_collector.collect(self.request)
 
-        packager = Packager()
+        packager = Packager(verbose=settings.VERBOSE)
         method = getattr(self, 'render_individual_{0}'.format(package_type))
 
         try:


### PR DESCRIPTION
This PR makes it possible to pass `verbose=True` to Pipeline using with a VERBOSE setting.

I considered making a PR which removes 'verbose' entirely and replaces it with the logging module, but you would still need a way to indicate that you wanted to pass the `--verbose` flag to compilers/compressors which support it (although this is only currently done in uglifyjs.py).

Regardless, if that seems like a better idea I could make a PR for it and see how it compares, but I think ether solution is better than the current situation where users can't set verbosity at all.
