### PR TITLE
Make the JS wrapper configurable

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -298,4 +298,7 @@ All javascript output is wrapped in an anonymous function : ::
 
 This safety wrapper, make it difficult to pollute the global namespace by accident and improve performance.
 
-You can override this behavior by setting ``DISABLE_WRAPPER`` to ``True``.
+You can override this behavior by setting ``DISABLE_WRAPPER`` to ``True``. If you want to use your own wrapper, change
+the ``JS_WRAPPER`` setting. For example: ::
+
+  JS_WRAPPER = "(function(){stuff();%s})();"

--- a/pipeline/compressors/__init__.py
+++ b/pipeline/compressors/__init__.py
@@ -62,7 +62,7 @@ class Compressor(object):
             js = js + self.compile_templates(templates)
 
         if not settings.DISABLE_WRAPPER:
-            js = "(function() {\n%s\n}).call(this);" % js
+            js = settings.JS_WRAPPER % js
 
         compressor = self.js_compressor
         if compressor:

--- a/pipeline/conf.py
+++ b/pipeline/conf.py
@@ -38,6 +38,7 @@ DEFAULTS = {
     'TEMPLATE_SEPARATOR': "_",
 
     'DISABLE_WRAPPER': False,
+    'JS_WRAPPER': "(function() {\n%s\n}).call(this);",
 
     'CSSTIDY_BINARY': '/usr/bin/env csstidy',
     'CSSTIDY_ARGUMENTS': '--template=highest',


### PR DESCRIPTION
For my application, I would like to wrap each JS file in a custom error handler but there's no nice way to change the JS wrapper right now. I made a new setting called `JS_WRAPPER` which defaults to the current wrapper code.