### PR TITLE
Respect storage.file_permissions_mode.

### DIFF
--- a/pipeline/compilers/__init__.py
+++ b/pipeline/compilers/__init__.py
@@ -40,6 +40,9 @@ class Compiler(object):
                     compiler.compile_file(infile, outfile,
                                           outdated=outdated, force=force)
 
+                    if getattr(self.storage, 'file_permissions_mode', None) is not None:
+                        os.chmod(outfile, self.storage.file_permissions_mode)
+
                     return compiler.output_path(input_path, compiler.output_extension)
             else:
                 return input_path


### PR DESCRIPTION
Per Django 1.7 Storages support file_permissions_mode to set filesystem
permissions on the generated files. Since Compilers generate files
outside the django.core.files.storage.save which takes care of setting
the permissions, we need to do it in Pipeline.
