### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,4 +26,4 @@ Documentation
 -------------
 
 For documentation, usage, and examples, see :
-https://django-pipeline.readthedocs.org
+https://django-pipeline.readthedocs.io

--- a/docs/compressors.rst
+++ b/docs/compressors.rst
@@ -161,7 +161,7 @@ Install the jsmin library with your favorite Python package manager ::
 SlimIt compressor
 =================
 
-The slimit compressor uses `SlimIt <http://slimit.readthedocs.org>`_ to
+The slimit compressor uses `SlimIt <https://slimit.readthedocs.io>`_ to
 compress javascripts.
 
 To use it add this to your ``PIPELINE['JS_COMPRESSOR']`` ::

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -78,7 +78,7 @@ Cache manifest
 ==============
 
 Pipeline provide a way to add your javascripts and stylesheets files to a
-cache-manifest via `Manifesto <http://manifesto.readthedocs.org/>`_.
+cache-manifest via `Manifesto <https://manifesto.readthedocs.io/>`_.
 
 To do so, you just need to add manifesto app to your ``INSTALLED_APPS``.
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.