### PR TITLE
CompillerException with proper error_output default value

### DIFF
--- a/pipeline/exceptions.py
+++ b/pipeline/exceptions.py
@@ -10,7 +10,7 @@ class PackageNotFound(PipelineException):
 
 
 class CompilerError(PipelineException):
-    def __init__(self, msg, command=None, error_output=None):
+    def __init__(self, msg, command=None, error_output=''):
         super(CompilerError, self).__init__(msg)
 
         self.command = command


### PR DESCRIPTION
NoneType have not strip method.
This is a issue for compilers, which do not provide the value of `error_output`.
https://github.com/facebookarchive/react-python/blob/master/react/utils/pipeline.py#L37