### PR TITLE
Added oudated, force check

### DIFF
--- a/pipeline/compilers/less.py
+++ b/pipeline/compilers/less.py
@@ -14,6 +14,8 @@ class LessCompiler(SubProcessCompiler):
 
     def compile_file(self, infile, outfile, outdated=False, force=False):
         # Pipe to file rather than provide outfile arg due to a bug in lessc
+        if not outdated and not force:
+            return
         command = (
             settings.LESS_BINARY,
             settings.LESS_ARGUMENTS,

--- a/pipeline/compilers/sass.py
+++ b/pipeline/compilers/sass.py
@@ -13,6 +13,8 @@ class SASSCompiler(SubProcessCompiler):
         return filename.endswith(('.scss', '.sass'))
 
     def compile_file(self, infile, outfile, outdated=False, force=False):
+        if not outdated and not force:
+            return
         command = (
             settings.SASS_BINARY,
             settings.SASS_ARGUMENTS,

--- a/pipeline/compilers/stylus.py
+++ b/pipeline/compilers/stylus.py
@@ -13,6 +13,8 @@ class StylusCompiler(SubProcessCompiler):
         return filename.endswith('.styl')
 
     def compile_file(self, infile, outfile, outdated=False, force=False):
+        if not outdated and not force:
+            return
         command = (
             settings.STYLUS_BINARY,
             settings.STYLUS_ARGUMENTS,


### PR DESCRIPTION
Without these your server application running with limited access will try to recompile files in directories it doesn't have access to (even though it was already compiled via `collectstatic`)