### PR TITLE
added compiler_options field

### DIFF
--- a/pipeline/compilers/__init__.py
+++ b/pipeline/compilers/__init__.py
@@ -26,7 +26,7 @@ class Compiler(object):
     def compilers(self):
         return [to_class(compiler) for compiler in settings.COMPILERS]
 
-    def compile(self, paths, force=False):
+    def compile(self, paths, compiler_options, force=False):
         def _compile(input_path):
             for compiler in self.compilers:
                 compiler = compiler(verbose=self.verbose, storage=self.storage)
@@ -38,7 +38,8 @@ class Compiler(object):
                     outfile = compiler.output_path(infile, compiler.output_extension)
                     outdated = compiler.is_outdated(infile, outfile)
                     compiler.compile_file(infile, outfile,
-                                          outdated=outdated, force=force)
+                                          outdated=outdated, force=force,
+                                          **compiler_options)
 
                     return compiler.output_path(input_path, compiler.output_extension)
             else:

--- a/pipeline/packager.py
+++ b/pipeline/packager.py
@@ -59,6 +59,10 @@ class Package(object):
     def manifest(self):
         return self.config.get('manifest', True)
 
+    @property
+    def compiler_options(self):
+        return self.config.get('compiler_options', {})
+
 
 class Packager(object):
     def __init__(self, storage=None, verbose=False, css_packages=None, js_packages=None):
@@ -95,14 +99,22 @@ class Packager(object):
                          output_filename=package.output_filename,
                          variant=package.variant, **kwargs)
 
-    def compile(self, paths, force=False):
-        return self.compiler.compile(paths, force=force)
+    def compile(self, paths, compiler_options, force=False):
+        return self.compiler.compile(
+            paths,
+            force=force,
+            compiler_options=compiler_options,
+        )
 
     def pack(self, package, compress, signal, **kwargs):
         output_filename = package.output_filename
         if self.verbose:
             print("Saving: %s" % output_filename)
-        paths = self.compile(package.paths, force=True)
+        paths = self.compile(
+            package.paths,
+            force=True,
+            compiler_options=package.compiler_options,
+        )
         content = compress(paths, **kwargs)
         self.save_file(output_filename, content)
         signal.send(sender=self, package=package, **kwargs)

--- a/pipeline/packager.py
+++ b/pipeline/packager.py
@@ -99,11 +99,11 @@ class Packager(object):
                          output_filename=package.output_filename,
                          variant=package.variant, **kwargs)
 
-    def compile(self, paths, compiler_options, force=False):
+    def compile(self, paths, compiler_options={}, force=False):
         return self.compiler.compile(
             paths,
-            force=force,
             compiler_options=compiler_options,
+            force=force,
         )
 
     def pack(self, package, compress, signal, **kwargs):
@@ -112,8 +112,8 @@ class Packager(object):
             print("Saving: %s" % output_filename)
         paths = self.compile(
             package.paths,
-            force=True,
             compiler_options=package.compiler_options,
+            force=True,
         )
         content = compress(paths, **kwargs)
         self.save_file(output_filename, content)


### PR DESCRIPTION
This commit adds an optional `compiler_options` field which can be provided in the package and is passed to the compiler. It's optional so shouldn't break anything currently working. I needed this so that I can handle cases like compiling multiple files with `browserify` and `factor-bundle` which requires multiple options per package.
