### PR TITLE
Remove empty args from argument_list in SubprocessCompiler

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -59,6 +59,7 @@ or just made Pipeline more awesome.
  * Jannis Leidel <jannis@leidel.info>
  * Jared Scott <jscott@convertro.com>
  * Jaromir Fojtu <jaromir.fojtu@gmail.com>
+ * Jeff Held <jheld135@gmail.com>
  * Jon Dufresne <jon.dufresne@gmail.com>
  * Josh Braegger <rckclmbr@gmail.com>
  * Joshua Kehn <josh@kehn.us>

--- a/pipeline/compilers/__init__.py
+++ b/pipeline/compilers/__init__.py
@@ -112,6 +112,8 @@ class SubProcessCompiler(CompilerBase):
             else:
                 argument_list.extend(flattening_arg)
 
+        # Filter out empty elements in argument_list
+        argument_list = filter(None, argument_list)
         stdout = None
         try:
             # We always catch stdout in a file, but we may not have a use for it.

--- a/pipeline/compilers/__init__.py
+++ b/pipeline/compilers/__init__.py
@@ -112,7 +112,8 @@ class SubProcessCompiler(CompilerBase):
             else:
                 argument_list.extend(flattening_arg)
 
-        # Filter out empty elements in argument_list
+        # The first element in argument_list is the program that will be executed; if it is '', then
+        # a PermissionError will be raised. Thus empty arguments are filtered out from argument_list
         argument_list = filter(None, argument_list)
         stdout = None
         try:


### PR DESCRIPTION
`argument_list` does not check if the first element is empty, which is problematic because, [by default](https://docs.python.org/3/library/subprocess.html#popen-constructor), that is the program that will be executed by `subprocess.Popen`, so, for example, if the first element in `argument_list` is an empty string, then a `PermissionError` will be raised. This came up when working with [django-pipeline-browserify](https://github.com/j0hnsmith/django-pipeline-browserify), because the first element in the command `BrowserifyCompiler` passes to `execute_command` is `BROWSERIFY_VARS`, which defaults to `''`. This commit will filter out empty elements in `argument_list` to prevent issues like this.