### PR TITLE
Start Django 1.10 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ env:
   - TOXENV=pypy-django19
   - TOXENV=py34-django19
   - TOXENV=py35-django19
+  - TOXENV=py27-django110
+  - TOXENV=pypy-django110
+  - TOXENV=py34-django110
+  - TOXENV=py35-django110
 docsinstall: pip install -q tox
 before_install:
   - nvm install node

--- a/AUTHORS
+++ b/AUTHORS
@@ -18,6 +18,7 @@ or just made Pipeline more awesome.
  * Andy Kish <agkish@gmail.com>
  * Ara Anjargolian <ara818@gmail.com>
  * Arnar Yngvason <arnar@hvitahusid.is>
+ * Austin Pua <pua.austin.anderson@gmail.com>
  * Axel Haustant <noirbizarre@gmail.com>
  * Balazs Kossovics <balazs.kossovics@e-loue.com>
  * Ben Vinegar <ben@benv.ca>

--- a/pipeline/middleware.py
+++ b/pipeline/middleware.py
@@ -6,8 +6,14 @@ from django.utils.html import strip_spaces_between_tags as minify_html
 
 from pipeline.conf import settings
 
+try:
+    # Support for Django 1.10 new MIDDLEWARE setting
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:  # Django < 1.10
+    MiddlewareMixin = object
 
-class MinifyHTMLMiddleware(object):
+
+class MinifyHTMLMiddleware(MiddlewareMixin):
     def __init__(self):
         if not settings.PIPELINE_ENABLED:
             raise MiddlewareNotUsed

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,6 @@
 import os
 
+import django
 from django.conf import settings
 from django.utils import six
 
@@ -17,6 +18,11 @@ def _(path):
 
 class pipeline_settings(override_settings):
     def __init__(self, **kwargs):
+        if django.VERSION[:2] >= (1, 10):
+            # Django 1.10's override_settings inherits from TestContextDecorator
+            # and its __init__ method calls its superclass' __init__ method too,
+            # so we must do the same.
+            super(pipeline_settings, self).__init__()
         self.options = {'PIPELINE': kwargs}
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    {py27,pypy,py34}-django{16,17,18,19},py35-django19,docs
+    {py27,pypy,py34}-django{16,17,18,19,110},py35-django{19,110},docs
 
 [testenv]
 basepython =
@@ -15,6 +15,7 @@ deps =
   django17: Django>=1.7,<1.8
   django18: Django>=1.8,<1.9
   django19: Django>=1.9,<1.10
+  django110: Django>=1.10,<1.11
   jinja2
   jsmin==2.2.0
   ply==3.4


### PR DESCRIPTION
I have not seen any Django 1.10 stuff yet, so I took the liberty of adding some envs for tox and travis CI. I also added support for Django 1.10's new style middleware and fixed some deprecation warnings.