### PR TITLE
Add support to Django 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ env:
   - TOXENV=pypy-django19
   - TOXENV=py34-django19
   - TOXENV=py35-django19
+  - TOXENV=py27-django19
+  - TOXENV=pypy-django110
+  - TOXENV=py34-django110
+  - TOXENV=py35-django110
 docsinstall: pip install -q tox
 before_install:
   - nvm install node
@@ -33,6 +37,6 @@ deploy:
   on:
     tags: true
     repo: jazzband/django-pipeline
-    condition: "$TOXENV = py27-django19"
+    condition: "$TOXENV = py27-django110"
 notifications:
   email: false

--- a/pipeline/middleware.py
+++ b/pipeline/middleware.py
@@ -3,14 +3,20 @@ from __future__ import unicode_literals
 from django.core.exceptions import MiddlewareNotUsed
 from django.utils.encoding import DjangoUnicodeDecodeError
 from django.utils.html import strip_spaces_between_tags as minify_html
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    # Django < 1.10
+    MiddlewareMixin = object
 
 from pipeline.conf import settings
 
 
-class MinifyHTMLMiddleware(object):
-    def __init__(self):
+class MinifyHTMLMiddleware(MiddlewareMixin):
+    def __init__(self, *args, **kwargs):
         if not settings.PIPELINE_ENABLED:
             raise MiddlewareNotUsed
+        super(MinifyHTMLMiddleware, self).__init__(*args, **kwargs)
 
     def process_response(self, request, response):
         if response.has_header('Content-Type') and 'text/html' in response['Content-Type']:

--- a/pipeline/templatetags/pipeline.py
+++ b/pipeline/templatetags/pipeline.py
@@ -135,7 +135,7 @@ class StylesheetNode(PipelineMixin, template.Node):
         try:
             package = self.package_for(package_name, 'css')
         except PackageNotFound:
-            logger.warn("Package %r is unknown. Check PIPELINE['STYLESHEETS'] in your settings.", package_name)
+            logger.warning("Package %r is unknown. Check PIPELINE['STYLESHEETS'] in your settings.", package_name)
             return ''  # fail silently, do not return anything if an invalid group is specified
         return self.render_compressed(package, package_name, 'css')
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -17,7 +17,7 @@ def _(path):
 
 class pipeline_settings(override_settings):
     def __init__(self, **kwargs):
-        self.options = {'PIPELINE': kwargs}
+        super(pipeline_settings, self).__init__(**{'PIPELINE': kwargs})
 
 
 # Django < 1.7 (copy-pasted from Django 1.7)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    {py27,pypy,py34}-django{16,17,18,19},py35-django19,docs
+    {py27,pypy,py34}-django{16,17,18,19,110},py35-django{19,110},docs
 
 [testenv]
 basepython =
@@ -15,6 +15,7 @@ deps =
   django17: Django>=1.7,<1.8
   django18: Django>=1.8,<1.9
   django19: Django>=1.9,<1.10
+  django110: Django>=1.10,<1.11
   jinja2
   jsmin==2.2.0
   ply==3.4


### PR DESCRIPTION
As the first commit says, the API change on middleware was not detected by tests. There may be some other sharp edges left so it should be considered as beta for Django 1.10 support.

Anyway, all tests for all Python and all other Django versions continue to pass.

Didn't bother to add me to authors, these changes are trivial.