### PR TITLE
Fix to view compile error if happens.

### DIFF
--- a/pipeline/templatetags/pipeline.py
+++ b/pipeline/templatetags/pipeline.py
@@ -116,12 +116,12 @@ class PipelineMixin(object):
         return method(package, paths, templates=templates)
 
     def render_error(self, package_type, package_name, e):
-        return render_to_string('pipeline/compile_error.html', Context({
+        return render_to_string('pipeline/compile_error.html', {
             'package_type': package_type,
             'package_name': package_name,
             'command': subprocess.list2cmdline(e.command),
             'errors': e.error_output,
-        }))
+        })
 
 
 class StylesheetNode(PipelineMixin, template.Node):


### PR DESCRIPTION
If compile error happens, we cannot see it. Instead, ‘context must be a dict rather than Context’.
Django 1.11. Regarding to docs, the same down to 1.7.