### PR TITLE
Fix css url detector regex.

### DIFF
--- a/pipeline/compressors/__init__.py
+++ b/pipeline/compressors/__init__.py
@@ -16,7 +16,7 @@ from pipeline.conf import settings
 from pipeline.exceptions import CompressorError
 from pipeline.utils import to_class, relpath, set_std_streams_blocking
 
-URL_DETECTOR = r"""url\((['"]){0,1}\s*(.*?)["']{0,1}\)"""
+URL_DETECTOR = r"""url\((['"]?)\s*(.*?)\1\)"""
 URL_REPLACER = r"""url\(__EMBED__(.+?)(\?\d+)?\)"""
 NON_REWRITABLE_URL = re.compile(r'^(#|http:|https:|data:|//)')
 

--- a/tests/assets/css/urls.css
+++ b/tests/assets/css/urls.css
@@ -1,3 +1,6 @@
+.embedded-url-svg {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath      stroke='rgba(255, 255, 255, 0.5)' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%     3C/svg%3E");
+}
 @font-face {
   font-family: 'Pipeline';
   src: url('../fonts/pipeline.eot');

--- a/tests/tests/test_compressor.py
+++ b/tests/tests/test_compressor.py
@@ -138,7 +138,10 @@ class CompressorTest(TestCase):
         output = self.compressor.concatenate_and_rewrite([
             _('pipeline/css/urls.css'),
         ], 'css/screen.css')
-        self.assertEqual("""@font-face {
+        self.assertEqual(""".embedded-url-svg {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath      stroke='rgba(255, 255, 255, 0.5)' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%     3C/svg%3E");
+}
+@font-face {
   font-family: 'Pipeline';
   src: url(../pipeline/fonts/pipeline.eot);
   src: url(../pipeline/fonts/pipeline.eot?#iefix) format('embedded-opentype');


### PR DESCRIPTION
Suggested fix for #615 
As the reporter of the original issue I also spotted it when minifying bootstrap.
The regex proposed in issue report was breaking quote-less urls tests by stripping the first path component. I've fixed it and this now works for my case as well as suits the test cases.