### PR TITLE
Add coverage badge, update package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 recursive-include pipeline/templates *.html *.jinja
 recursive-include pipeline/jinja2 *.html *.jinja
-include AUTHORS LICENSE README.rst HISTORY.rst
+include AUTHORS LICENSE README.rst HISTORY.rst CONTRIBUTING.rst
 recursive-include tests *
 recursive-exclude tests *.pyc *.pyo
 recursive-exclude tests/node_modules *
@@ -8,3 +8,4 @@ recursive-exclude tests/npm-cache *
 recursive-exclude tests/npm *
 include docs/Makefile docs/make.bat docs/conf.py
 recursive-include docs *.rst
+exclude package.json requirements.txt tox.ini

--- a/README.rst
+++ b/README.rst
@@ -5,10 +5,14 @@ Pipeline
     :alt: Build Status
     :target: http://travis-ci.org/jazzband/django-pipeline
 
+.. image:: https://coveralls.io/repos/github/jazzband/django-pipeline/badge.svg?branch=master
+    :alt: Code Coverage
+    :target: https://coveralls.io/github/jazzband/django-pipeline?branch=master
+
 .. image:: https://jazzband.co/static/img/badge.svg
     :alt: Jazzband
     :target: https://jazzband.co/
-   
+
 .. image:: https://badge.fury.io/py/django-pipeline.svg
     :alt: PYPI
     :target: https://badge.fury.io/py/django-pipeline

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,8 @@ setup(
     zip_safe=False,
     install_requires=install_requires,
     include_package_data=True,
+    keywords=('django pipeline asset compiling concatenation compression'
+              ' packaging'),
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',


### PR DESCRIPTION
Some small fixes before a 1.6.13 release:

- Add a code coverage badge to the readme, linking to [coveralls](https://coveralls.io/github/jazzband/django-pipeline).
- Add keywords to setup.py, so that a search for [django-pipeline on PyPI](https://pypi.python.org/pypi?%3Aaction=search&term=django-pipeline&submit=search) is more likely to find the package, and to make [pyroma](https://pypi.python.org/pypi/pyroma) happy.
- Update MANIFEST.in to make [check-manifest](https://pypi.python.org/pypi/check-manifest) happy.