### PR TITLE
Create manifest pipeline storage

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -118,3 +118,4 @@ or just made Pipeline more awesome.
  * Wismill
  * Zachary Kazanski <kazanski.zachary@gmail.com>
  * Zenobius Jiricek <zenobius.jiricek@gmail.com>
+ * Zeus Kronion

--- a/docs/storages.rst
+++ b/docs/storages.rst
@@ -15,15 +15,20 @@ to use it configure ``STATICFILES_STORAGE`` like so ::
 
 And if you want versioning use ::
 
+  # Select one of the following
+  STATICFILES_STORAGE = 'pipeline.storage.PipelineManifestStorage'  # Preferred
   STATICFILES_STORAGE = 'pipeline.storage.PipelineCachedStorage'
 
-There is also non-packing storage available, that allows you to run ``collectstatic`` command
+
+There are also non-packing storages available, that allows you to run ``collectstatic`` command
 without packaging your assets. Useful for production when you don't want to run compressor or compilers ::
 
   STATICFILES_STORAGE = 'pipeline.storage.NonPackagingPipelineStorage'
 
 Also available if you want versioning ::
 
+  # Select one of the following
+  STATICFILES_STORAGE = 'pipeline.storage.NonPackagingPipelineManifestStorage'  # Preferred
   STATICFILES_STORAGE = 'pipeline.storage.NonPackagingPipelineCachedStorage'
 
 If you use staticfiles with ``DEBUG = False`` (i.e. for integration tests

--- a/pipeline/storage.py
+++ b/pipeline/storage.py
@@ -4,7 +4,7 @@ import gzip
 
 from io import BytesIO
 
-from django.contrib.staticfiles.storage import CachedStaticFilesStorage, StaticFilesStorage
+from django.contrib.staticfiles.storage import CachedStaticFilesStorage, ManifestStaticFilesStorage, StaticFilesStorage
 from django.contrib.staticfiles.utils import matches_patterns
 
 from django.core.files.base import File
@@ -89,6 +89,14 @@ class PipelineStorage(PipelineMixin, StaticFilesStorage):
 
 
 class NonPackagingPipelineStorage(NonPackagingMixin, PipelineStorage):
+    pass
+
+
+class PipelineManifestStorage(PipelineMixin, ManifestStaticFilesStorage):
+    pass
+
+
+class NonPackagingPipelineManifestStorage(NonPackagingMixin, ManifestStaticFilesStorage):
     pass
 
 


### PR DESCRIPTION
ManifestStaticFilesStorage is generally preferred to CachedStaticFilesStorage (see https://docs.djangoproject.com/en/dev/ref/contrib/staticfiles/#cachedstaticfilesstorage), so provide a Pipeline storage for it as well.