### PR TITLE
Don't require NoopCompressor to be specified when PIPELINE_ENABLED=False

### DIFF
--- a/pipeline/compressors/__init__.py
+++ b/pipeline/compressors/__init__.py
@@ -49,10 +49,14 @@ class Compressor(object):
 
     @property
     def js_compressor(self):
+        if not settings.PIPELINE_ENABLED:
+            return NoopCompressor
         return to_class(settings.JS_COMPRESSOR)
 
     @property
     def css_compressor(self):
+        if not settings.PIPELINE_ENABLED:
+            return NoopCompressor
         return to_class(settings.CSS_COMPRESSOR)
 
     def compress_js(self, paths, templates=None, **kwargs):


### PR DESCRIPTION
Addresses the issue I reported in #641.