### PR TITLE
Fix tests to pass with yuglify 1.0.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "cssmin": "latest",
     "google-closure-compiler": "latest",
     "uglify-js": "latest",
-    "yuglify": "latest",
+    "yuglify": "1.0.x",
     "yuicompressor": "latest"
   }
 }

--- a/tests/assets/compressors/yuglify.js
+++ b/tests/assets/compressors/yuglify.js
@@ -1,1 +1,1 @@
-(function(){(function(){window.concat=function(){console.log(arguments)}})(),function(){window.cat=function(){console.log("hello world")}}()}).call(this);
+(function(){!function(){window.concat=function(){console.log(arguments)}}(),function(){window.cat=function(){console.log("hello world")}}()}).call(this);


### PR DESCRIPTION
npm was always installing the latest version of yuglify (now 1.0.1), but the cached expected test output was for version 0.1. I'm in favor of pinning the yuglify version to install so that the tests don't have to be fixed every time yuglify makes a change.