### PR TITLE
Update pipeline\conf.py

### DIFF
--- a/pipeline/conf.py
+++ b/pipeline/conf.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 import os
-import collections
+from collections import MutableMapping
 import shlex
 
 from django.conf import settings as _settings
@@ -91,7 +91,7 @@ DEFAULTS = {
 }
 
 
-class PipelineSettings(collections.MutableMapping):
+class PipelineSettings(MutableMapping):
     """
     Container object for pipeline settings
     """


### PR DESCRIPTION
Fix deprecated import, who will stop working in python 3.8.

```
$ python -Wa manage.py check
C:\Program Files\Python3.7\lib\site-packages\pipeline\conf.py:94: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
  class PipelineSettings(collections.MutableMapping):
```