### PR TITLE
Fixed a bug in css.html not defaulting media attribute to 'all'.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -67,6 +67,7 @@ or just made Pipeline more awesome.
  * Josh Braegger <rckclmbr@gmail.com>
  * Joshua Kehn <josh@kehn.us>
  * Julien Hartmann <julien@etherdream.org>
+ * Kevin Fox <kevin_fox@me.com> (@KFoxder)
  * Kristian Glass <git@doismellburning.co.uk>
  * Kyle MacFarlane <kyle@deletethetrees.com>
  * Leonardo Orozco <leonardoorozcop@gmail.com>

--- a/pipeline/templates/pipeline/css.html
+++ b/pipeline/templates/pipeline/css.html
@@ -1,1 +1,1 @@
-<link href="{{ url }}" rel="stylesheet" type="{{ type }}"{% if media %} media="{{ media }}"{% endif %}{% if title %} title="{{ title|default:"all" }}"{% endif %}{% if charset %} charset="{{ charset }}"{% endif %} />
+<link href="{{ url }}" rel="stylesheet" type="{{ type }}" media="{{ media|default:"all" }}"{% if title %} title="{{ title }}"{% endif %}{% if charset %} charset="{{ charset }}"{% endif %} />

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -70,6 +70,28 @@ PIPELINE = {
                 'pipeline/css/urls.css'
             ),
             'output_filename': 'screen.css'
+        },
+        'screen_media': {
+            'source_filenames': (
+                'pipeline/css/first.css',
+                'pipeline/css/second.css',
+                'pipeline/css/urls.css'
+            ),
+            'output_filename': 'screen_media.css',
+            'extra_context': {
+                'media': 'screen and (min-width:500px)',
+            },
+        },
+        'screen_title': {
+            'source_filenames': (
+                'pipeline/css/first.css',
+                'pipeline/css/second.css',
+                'pipeline/css/urls.css'
+            ),
+            'output_filename': 'screen_title.css',
+            'extra_context': {
+                'title': 'Default Style',
+            },
         }
     },
     'JAVASCRIPT': {

--- a/tests/tests/test_template.py
+++ b/tests/tests/test_template.py
@@ -56,11 +56,19 @@ class DjangoTest(TestCase):
 
     def test_compressed_empty(self):
         rendered = self.render_template(u"""{% load pipeline %}{% stylesheet "unknow" %}""")
-        self.assertEqual(u"", rendered)
+        self.assertEqual(u'', rendered)
 
     def test_compressed_css(self):
         rendered = self.render_template(u"""{% load pipeline %}{% stylesheet "screen" %}""")
-        self.assertEqual(u'<link href="/static/screen.css" rel="stylesheet" type="text/css" />', rendered)
+        self.assertEqual(u'<link href="/static/screen.css" rel="stylesheet" type="text/css" media="all" />', rendered)
+
+    def test_compressed_css_media(self):
+        rendered = self.render_template(u"""{% load pipeline %}{% stylesheet "screen_media" %}""")
+        self.assertEqual(u'<link href="/static/screen_media.css" rel="stylesheet" type="text/css" media="screen and (min-width:500px)" />', rendered)
+
+    def test_compressed_css_title(self):
+        rendered = self.render_template(u"""{% load pipeline %}{% stylesheet "screen_title" %}""")
+        self.assertEqual(u'<link href="/static/screen_title.css" rel="stylesheet" type="text/css" media="all" title="Default Style" />', rendered)
 
     def test_compressed_js(self):
         rendered = self.render_template(u"""{% load pipeline %}{% javascript "scripts" %}""")


### PR DESCRIPTION
The documentation for the [`extra_context`](https://django-pipeline.readthedocs.io/en/1.6.14/configuration.html#extra-context) option says:
> For CSS, if you do not specify extra_context/media, the default media in the <link> output will be media="all".

Related Issue: https://github.com/jazzband/django-pipeline/issues/684