### PR TITLE
Compile from project file

### DIFF
--- a/pipeline/compilers/__init__.py
+++ b/pipeline/compilers/__init__.py
@@ -36,9 +36,10 @@ class Compiler(object):
                         infile = self.storage.path(input_path)
                     except NotImplementedError:
                         infile = finders.find(input_path)
+                    project_infile = finders.find(input_path)
                     outfile = compiler.output_path(infile, compiler.output_extension)
-                    outdated = compiler.is_outdated(infile, outfile)
-                    compiler.compile_file(infile, outfile,
+                    outdated = compiler.is_outdated(project_infile, outfile)
+                    compiler.compile_file(project_infile, outfile,
                                           outdated=outdated, force=force,
                                           **compiler_options)
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import sys
 
 setup(
     name='django-pipeline',
-    version='1.6.14',
+    version='1.6.14.1   ',
     description='Pipeline is an asset packaging library for Django.',
     long_description=io.open('README.rst', encoding='utf-8').read() + '\n\n' +
         io.open('HISTORY.rst', encoding='utf-8').read(),

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import sys
 
 setup(
     name='django-pipeline',
-    version='1.6.14.1   ',
+    version='1.6.14',
     description='Pipeline is an asset packaging library for Django.',
     long_description=io.open('README.rst', encoding='utf-8').read() + '\n\n' +
         io.open('HISTORY.rst', encoding='utf-8').read(),


### PR DESCRIPTION
Use the file from the project to check outdated and as source for the compiler. This way the PIPELINE_COLLECTOR_ENABLED property can be set to False, which saves time during development.