### PR TITLE
Add terser (JS compressor for ES5 and ES6)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -54,6 +54,7 @@ or just made Pipeline more awesome.
  * Evan Myller <eMyller@7ws.co>
  * Fabian Büchler <fabian.buechler@gmail.com>
  * Feanil Patel <feanil@edx.org>
+ * Felix Last <mail@felixlast.de>
  * Florent Messa <florent.messa@gmail.com>
  * Frankie Dintino <fdintino@theatlantic.com>
  * Hannes Ljungberg <hannes.ljungberg@gmail.com>

--- a/docs/compressors.rst
+++ b/docs/compressors.rst
@@ -173,6 +173,35 @@ Install the slimit library with your favorite Python package manager ::
   pip install slimit
 
 
+Terser compressor
+===================
+
+`Terser <https://github.com/terser/terser>`_ is a JavaScript parser and 
+mangler/compressor toolkit for ES6+. It has been designed as a successor of
+``uglify-es`` and ``uglify-js``. The compressor works with ES5 and ES6 and 
+regular ``.js`` file endings.
+
+To use it add this to your ``PIPELINE['JS_COMPRESSOR']`` ::
+
+  PIPELINE['JS_COMPRESSOR'] = 'pipeline.compressors.terser.TerserCompressor'
+
+
+``TERSER_BINARY``
+----------------------------
+
+  Command line to execute for the terser program.
+  You will most likely change this to the location of terser on your system.
+
+  Defaults to ``'/usr/bin/env terser'``.
+
+``TERSER_ARGUMENTS``
+-------------------------------
+
+  Additional arguments to use when terser is called.
+
+  Default to ``'--compress'``
+
+
 CSSTidy compressor
 ==================
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "stylus": "latest",
     "cssmin": "latest",
     "google-closure-compiler": "latest",
+    "terser": "latest",
     "uglify-js": "latest",
     "yuglify": "1.0.x",
     "yuicompressor": "latest"

--- a/pipeline/compressors/terser.py
+++ b/pipeline/compressors/terser.py
@@ -1,0 +1,12 @@
+from __future__ import unicode_literals
+
+from pipeline.conf import settings
+from pipeline.compressors import SubProcessCompressor
+
+
+class TerserCompressor(SubProcessCompressor):
+    def compress_js(self, js):
+        command = (settings.TERSER_BINARY, settings.TERSER_ARGUMENTS)
+        if self.verbose:
+            command += ' --verbose'
+        return self.execute_command(command, js)

--- a/pipeline/conf.py
+++ b/pipeline/conf.py
@@ -48,6 +48,9 @@ DEFAULTS = {
 
     'UGLIFYJS_BINARY': '/usr/bin/env uglifyjs',
     'UGLIFYJS_ARGUMENTS': '',
+    
+    'TERSER_BINARY': '/usr/bin/env terser',
+    'TERSER_ARGUMENTS': '--compress',
 
     'CSSMIN_BINARY': '/usr/bin/env cssmin',
     'CSSMIN_ARGUMENTS': '',

--- a/tests/assets/compressors/terser.js
+++ b/tests/assets/compressors/terser.js
@@ -1,0 +1,1 @@
+(function(){window.concat=function(){console.log(arguments)},window.cat=function(){console.log("hello world")}}).call(this);

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -170,6 +170,7 @@ if HAS_NODE:
         'LIVE_SCRIPT_ARGUMENTS': ['--no-header'],
         'YUGLIFY_BINARY': node_exe_path('yuglify'),
         'UGLIFYJS_BINARY': node_exe_path('uglifyjs'),
+        'TERSER_BINARY': node_exe_path('terser'),
         'CSSMIN_BINARY': node_exe_path('cssmin'),
     })
 

--- a/tests/tests/test_compressor.py
+++ b/tests/tests/test_compressor.py
@@ -240,7 +240,12 @@ class CompressorImplementationTest(TestCase):
     def test_uglifyjs(self):
         self._test_compressor('pipeline.compressors.uglifyjs.UglifyJSCompressor',
             'js', 'pipeline/compressors/uglifyjs.js')
-        
+
+    @skipUnless(settings.HAS_NODE, "requires node")
+    def test_terser(self):
+        self._test_compressor('pipeline.compressors.terser.TerserCompressor',
+            'js', 'pipeline/compressors/terser.js')
+
     @skipUnless(settings.HAS_NODE, "requires node")
     def test_yuglify(self):
         self._test_compressor('pipeline.compressors.yuglify.YuglifyCompressor',


### PR DESCRIPTION
Add [terser](https://github.com/terser/terser) as a JS compressor which can handle both ES5 and ES6 syntax.