### PR TITLE
use install_requires instead of extras_require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     license='MIT',
     packages=find_packages(exclude=['tests', 'tests.tests']),
     zip_safe=False,
-    extras_require={ ':python_version<"3"': ['futures>=2.1.3'] },
+    install_requires=['futures >= 2.1.3;python_version<"3"'],
     include_package_data=True,
     keywords=('django pipeline asset compiling concatenation compression'
               ' packaging'),


### PR DESCRIPTION
I noticed that for my application running python 3.6 that installing `django-pipeline` was still installing `futures`, which is both not recommended and not needed. This PR modifies the setup arguments to match the [setuptools docs](https://setuptools.readthedocs.io/en/latest/setuptools.html#id17) for declaring platform specific dependencies.

Let me know what you think and if there's anything else I can do here :)