### PR TITLE
Override bug in find() method

### DIFF
--- a/pipeline/finders.py
+++ b/pipeline/finders.py
@@ -13,10 +13,7 @@ class PipelineFinder(BaseStorageFinder):
     storage = staticfiles_storage
 
     def find(self, path, all=False):
-        if not settings.PIPELINE_ENABLED:
-            return super(PipelineFinder, self).find(path, all)
-        else:
-            return []
+        return super(PipelineFinder, self).find(path, all)
 
     def list(self, ignore_patterns):
         return []


### PR DESCRIPTION
There is a bug in django-pipeline that prevents the files in the PIPELINE settings config from collecting those static assets when running `python manage.py collectstatic`. See stack overflow: https://github.com/jazzband/django-pipeline/issues/487#issuecomment-132335903