### PR TITLE
Fix 691 - HTML not getting decoded properly by Middleware in Django 2.2

### DIFF
--- a/pipeline/middleware.py
+++ b/pipeline/middleware.py
@@ -18,7 +18,7 @@ class MinifyHTMLMiddleware(MiddlewareMixin):
     def process_response(self, request, response):
         if response.has_header('Content-Type') and 'text/html' in response['Content-Type']:
             try:
-                response.content = minify_html(response.content.strip())
+                response.content = minify_html(response.content.decode().strip())
                 response['Content-Length'] = str(len(response.content))
             except DjangoUnicodeDecodeError:
                 pass


### PR DESCRIPTION
Fix #691
