### PR TITLE
Keep mimetypes as str on all versions of Python

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -21,6 +21,7 @@ or just made Pipeline more awesome.
  * Austin Pua <pua.austin.anderson@gmail.com>
  * Axel Haustant <noirbizarre@gmail.com>
  * Balazs Kossovics <balazs.kossovics@e-loue.com>
+ * Ben Spaulding <ben@spaulding.im>
  * Ben Vinegar <ben@benv.ca>
  * Brad Pitcher <bradpitcher@gmail.com>
  * Brant Young <brant.young@gmail.com>

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -231,11 +231,11 @@ Tuple that match file extension with their corresponding mimetypes.
 Defaults to ::
 
   (
-    (b'text/coffeescript', '.coffee'),
-    (b'text/less', '.less'),
-    (b'text/javascript', '.js'),
-    (b'text/x-sass', '.sass'),
-    (b'text/x-scss', '.scss')
+    ('text/coffeescript', '.coffee'),
+    ('text/less', '.less'),
+    ('text/javascript', '.js'),
+    ('text/x-sass', '.sass'),
+    ('text/x-scss', '.scss')
   )
 
 .. warning::

--- a/pipeline/conf.py
+++ b/pipeline/conf.py
@@ -71,11 +71,11 @@ DEFAULTS = {
     'LESS_ARGUMENTS': '',
 
     'MIMETYPES': (
-        (b'text/coffeescript', '.coffee'),
-        (b'text/less', '.less'),
-        (b'text/javascript', '.js'),
-        (b'text/x-sass', '.sass'),
-        (b'text/x-scss', '.scss')
+        (str('text/coffeescript'), str('.coffee')),
+        (str('text/less'), str('.less')),
+        (str('text/javascript'), str('.js')),
+        (str('text/x-sass'), str('.sass')),
+        (str('text/x-scss'), str('.scss'))
     ),
 
     'EMBED_MAX_IMAGE_SIZE': 32700,

--- a/tests/tests/test_utils.py
+++ b/tests/tests/test_utils.py
@@ -1,3 +1,8 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import mimetypes
+
 from django.test import TestCase
 
 from pipeline.utils import guess_type
@@ -8,3 +13,8 @@ class UtilTest(TestCase):
         self.assertEqual('text/css', guess_type('stylesheet.css'))
         self.assertEqual('text/coffeescript', guess_type('application.coffee'))
         self.assertEqual('text/less', guess_type('stylesheet.less'))
+
+    def test_mimetypes_are_str(self):
+        for ext, mtype in mimetypes.types_map.items():
+            self.assertIsInstance(ext, str)
+            self.assertIsInstance(mtype, str)


### PR DESCRIPTION
As noted in jazzband/django-pipeline#297 the mimetypes should not be `unicode` *on Python 2*. But they *should be `str`* on Python 3.

This fix ensures that `pipeline.utils.guess_type` only adds types and extensions as `str` to the core `mimetypes.types_map`.

Caused by: jazzband/django-pipeline#297
Effecting:
- pallets/werkzeug#636
- pallets/werkzeug#637