### PR TITLE
Add complet support for Django 3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,14 @@ matrix:
     python: '3.7'
   - env: TOXENV=py38-django30
     python: '3.8'
+  - env: TOXENV=pypy3-django31
+    python: pypy3
+  - env: TOXENV=py36-django31
+    python: '3.6'
+  - env: TOXENV=py37-django31
+    python: '3.7'
+  - env: TOXENV=py38-django31
+    python: '3.8'
   - env: TOXENV=py36-django-master
     python: '3.6'
   - env: TOXENV=py37-django-master

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,8 @@ History
   of the current version to prevent error while importing. Thank to @vmsp
 * Context in django.template.base is removed from Django and
   not used anymore in django-pipeline.
+* Fixing widgets tests of django-pipeline due to Media.render_js change in 
+  Django. More information in Django ticket #31892
 
 2.0.4
 ======

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,15 @@
 History
 =======
 
+2.0.5
+======
+
+* Adding **Django 3.1** compatibility.
+* CachedStaticFilesStorage is removed from Django. Add a check
+  of the current version to prevent error while importing. Thank to @vmsp
+* Context in django.template.base is removed from Django and
+  not used anymore in django-pipeline.
+
 2.0.4
 ======
 

--- a/pipeline/storage.py
+++ b/pipeline/storage.py
@@ -2,9 +2,9 @@ import gzip
 
 from io import BytesIO
 
-import django
+from django import get_version as django_version
 
-_CACHED_STATIC_FILES_STORAGE_AVAILABLE = django.VERSION[0] <= 3 and django.VERSION[1] < 1
+_CACHED_STATIC_FILES_STORAGE_AVAILABLE = django_version() < '3.1'
 
 if _CACHED_STATIC_FILES_STORAGE_AVAILABLE:
     from django.contrib.staticfiles.storage import CachedStaticFilesStorage

--- a/pipeline/templatetags/pipeline.py
+++ b/pipeline/templatetags/pipeline.py
@@ -4,7 +4,6 @@ import subprocess
 from django.contrib.staticfiles.storage import staticfiles_storage
 
 from django import template
-from django.template.context import Context
 from django.template.base import VariableDoesNotExist
 from django.template.loader import render_to_string
 from django.utils.safestring import mark_safe

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import sys
 
 setup(
     name='django-pipeline',
-    version='2.0.4',
+    version='2.0.5',
     description='Pipeline is an asset packaging library for Django.',
     long_description=io.open('README.rst', encoding='utf-8').read() + '\n\n' +
         io.open('HISTORY.rst', encoding='utf-8').read(),
@@ -25,6 +25,7 @@ setup(
         'Framework :: Django',
         'Framework :: Django :: 2.2',
         'Framework :: Django :: 3.0',
+        'Framework :: Django :: 3.1',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',

--- a/tests/tests/test_forms.py
+++ b/tests/tests/test_forms.py
@@ -1,3 +1,4 @@
+from django import get_version as django_version
 from django.forms import Media
 from django.test import TestCase
 
@@ -147,6 +148,7 @@ class PipelineFormMediaTests(TestCase):
             js = ('extra1.js', 'extra2.js')
 
         media = Media(MyMedia)
+        script_tag = '<script type="text/javascript" src="%s"></script>' if django_version() < '3.1' else '<script src="%s"></script>'
 
         self.assertEqual(
             MyMedia.js,
@@ -160,7 +162,7 @@ class PipelineFormMediaTests(TestCase):
         self.assertEqual(
             media.render_js(),
             [
-                '<script type="text/javascript" src="%s"></script>' % path
+                script_tag % path
                 for path in (
                     '/static/extra1.js',
                     '/static/extra2.js',
@@ -177,6 +179,7 @@ class PipelineFormMediaTests(TestCase):
             js = ('extra1.js', 'extra2.js')
 
         media = Media(MyMedia)
+        script_tag = '<script type="text/javascript" src="%s"></script>' if django_version() < '3.1' else '<script src="%s"></script>'
 
         self.assertEqual(
             MyMedia.js,
@@ -191,7 +194,7 @@ class PipelineFormMediaTests(TestCase):
         self.assertEqual(
             media.render_js(),
             [
-                '<script type="text/javascript" src="%s"></script>' % path
+                script_tag % path
                 for path in (
                     '/static/extra1.js',
                     '/static/extra2.js',

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
-  pypy3-django{22,30}
-  py36-django{22,30,-master}
-  py37-django{22,30,-master}
-  py38-django{22,30,-master}
+  pypy3-django{22,30,31}
+  py36-django{22,30,31,-master}
+  py37-django{22,30,31,-master}
+  py38-django{22,30,31,-master}
   docs
 
 [testenv]
@@ -16,6 +16,7 @@ deps =
   pypy3: mock
   django22: Django>=2.2.1,<2.3
   django30: Django>=3.0,<3.1
+  django31: Django>=3.1,<3.2
   django-master: https://github.com/django/django/archive/master.tar.gz
   jinja2
   coverage


### PR DESCRIPTION
Improvement to check Django version to prevent import errors in storage.py
Add Travis tests for Django 3.1 with python 3.6, 3.7, 3.8 and pypy3.
Change tests after an undocumented change in Media.render_js from Django
Related issue: https://code.djangoproject.com/ticket/31892