### PR TITLE
removes django deprecation warning

### DIFF
--- a/pipeline/signals.py
+++ b/pipeline/signals.py
@@ -1,5 +1,5 @@
 from django.dispatch import Signal
 
 
-css_compressed = Signal(providing_args=["package"])
-js_compressed = Signal(providing_args=["package"])
+css_compressed = Signal()
+js_compressed = Signal()


### PR DESCRIPTION
When `signals.py` is used in a django project, we get the following warning

```app\venv\lib\site-packages\pipeline\signals.py:5: RemovedInDjango40Warning: The providing_args argument is deprecated. As it is purely documentational, it has no replacement. If you rely on this argument as documentation, you can move the text to a code comment or docstring.```

I'm removing this to stop the noise.