### PR TITLE
Add SVG as an embeddable file type

### DIFF
--- a/pipeline/compressors/__init__.py
+++ b/pipeline/compressors/__init__.py
@@ -25,6 +25,7 @@ MIME_TYPES = {
     '.jpg': 'image/jpeg',
     '.jpeg': 'image/jpeg',
     '.gif': 'image/gif',
+    '.svg': 'image/svg+xml',
     '.tif': 'image/tiff',
     '.tiff': 'image/tiff',
     '.ttf': 'font/truetype',


### PR DESCRIPTION
This adds SVG as a file type that can be embedded when the `'variant': 'datauri'` feature is enabled.

Alternatively, I've seen there's PR #539, which solves the same problem by making it a configuration option.