### PR TITLE
Fix deprecation warnings from Django

### DIFF
--- a/pipeline/signals.py
+++ b/pipeline/signals.py
@@ -1,5 +1,5 @@
 from django.dispatch import Signal
 
 
-css_compressed = Signal(providing_args=["package"])
-js_compressed = Signal(providing_args=["package"])
+css_compressed = Signal()
+js_compressed = Signal()

--- a/pipeline/utils.py
+++ b/pipeline/utils.py
@@ -12,7 +12,7 @@ import sys
 
 from urllib.parse import quote
 
-from django.utils.encoding import smart_text
+from django.utils.encoding import smart_str
 
 from pipeline.conf import settings
 
@@ -30,7 +30,7 @@ def to_class(class_str):
 def filepath_to_uri(path):
     if path is None:
         return path
-    return quote(smart_text(path).replace("\\", "/"), safe="/~!*()'#?")
+    return quote(smart_str(path).replace("\\", "/"), safe="/~!*()'#?")
 
 
 def guess_type(path, default=None):
@@ -39,7 +39,7 @@ def guess_type(path, default=None):
     mimetype, _ = mimetypes.guess_type(path)
     if not mimetype:
         return default
-    return smart_text(mimetype)
+    return smart_str(mimetype)
 
 
 def relpath(path, start=posixpath.curdir):


### PR DESCRIPTION
Fixes this deprecation warnings from django:

- RemovedInDjango40Warning: smart_text() is deprecated in favor of smart_str()
- RemovedInDjango40Warning: The providing_args argument is deprecated. As it is purely documentational, it has no replacement. If you rely on this argument as documentation, you can move the text to a code comment or docstring.