### PR TITLE
Replace deprecated `force_text` with `force_str` (which is being dropped in Django 4.0)

### DIFF
--- a/pipeline/compressors/__init__.py
+++ b/pipeline/compressors/__init__.py
@@ -7,7 +7,7 @@ import subprocess
 from itertools import takewhile
 
 from django.contrib.staticfiles.storage import staticfiles_storage
-from django.utils.encoding import smart_bytes, force_text
+from django.utils.encoding import smart_bytes, force_str
 
 from pipeline.conf import settings
 from pipeline.exceptions import CompressorError
@@ -183,7 +183,7 @@ class Compressor(object):
         if path in self.__class__.asset_contents:
             return self.__class__.asset_contents[path]
         data = self.read_bytes(path)
-        self.__class__.asset_contents[path] = force_text(base64.b64encode(data))
+        self.__class__.asset_contents[path] = force_str(base64.b64encode(data))
         return self.__class__.asset_contents[path]
 
     def mime_type(self, path):
@@ -217,7 +217,7 @@ class Compressor(object):
 
     def read_text(self, path):
         content = self.read_bytes(path)
-        return force_text(content)
+        return force_str(content)
 
 
 class CompressorBase(object):
@@ -250,7 +250,7 @@ class SubProcessCompressor(CompressorBase):
             raise CompressorError(stderr)
         elif self.verbose:
             print(stderr)
-        return force_text(stdout)
+        return force_str(stdout)
 
 
 class NoopCompressor(CompressorBase):


### PR DESCRIPTION
I was just trying out the [Django 4.0 alpha 1](https://www.djangoproject.com/weblog/2021/sep/21/django-40-alpha-1-released/) in a project and `force_text` has been removed in [Django 4.0](https://docs.djangoproject.com/en/dev/releases/4.0/#features-removed-in-4-0) (was deprecated in [3.0](https://docs.djangoproject.com/en/dev/releases/3.0/#django-utils-encoding-force-text-and-smart-text)).

In Django 3.0 to 3.2 it was [just an alias](https://github.com/django/django/blob/stable/3.2.x/django/utils/encoding.py#L110-L115) to `force_str`.