### PR TITLE
Docs: update `HISTORY.rst` to reflect `2.0.6` release and unreleased changes

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,7 +6,14 @@ History
 Unreleased
 ==========
 
-* Moving tests to GitHub Actions: https://github.com/jazzband/django-pipeline/actions
+* Added **Django 3.2** compatibility (Thanks to @jramnai in #751)
+
+2.0.6
+======
+
+* Added terser (JS compressor for ES5 and ES6) (Thanks to @felix-last in #696)
+* Moved tests to GitHub Actions: https://github.com/jazzband/django-pipeline/actions (#738)
+* Fixed deprecation warnings from Django (Thanks to @edelvalle in #731)
 
 2.0.5
 ======


### PR DESCRIPTION
Just following up from [the comment here](https://github.com/jazzband/django-pipeline/issues/752#issuecomment-908318726) about the outdated `HISTORY.rst` file being a release blocker.

- Added the missing `2.0.6` release notes based on https://github.com/jazzband/django-pipeline/compare/2.0.5...2.0.6
- Added the `unreleased` notes based on the (current) https://github.com/jazzband/django-pipeline/compare/2.0.6...master
- As for style of release notes, have used past tense ("added" rather than "add"/"adding") since it was previously a bit inconsistent, have included relevant PR numbers, and where it's a first time contributor have included the user's name. Not sure if jazzband has any release note standards so feel free to modify as you like...

Hopefully we can get a new release (and focus on Django 4.0 compatibility next)