### PR TITLE
Update testing matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,13 +9,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', 'pypy3']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', 'pypy3']
         django-version: ['2.2', '3.0', '3.1', '3.2', 'main']
         exclude:
           - python-version: '3.6'
             django-version: 'main'
           - python-version: '3.7'
             django-version: 'main'
+          - python-version: '3.10'
+            django-version: '2.2'
+          - python-version: '3.10'
+            django-version: '3.0'
+          - python-version: '3.10'
+            django-version: '3.1'
+          - python-version: '3.10'
+            django-version: '3.2'
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,16 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', 'pypy3']
-        django-version: ['2.2', '3.0', '3.1', '3.2', 'main']
+        django-version: ['2.2', '3.0', '3.1', '3.2', '4.0', 'main']
         exclude:
           - python-version: '3.6'
+            django-version: '4.0'
+          - python-version: '3.6'
             django-version: 'main'
+          - python-version: '4.0'
+            django-version: 'main'
+          - python-version: '3.7'
+            django-version: '4.0'
           - python-version: '3.7'
             django-version: 'main'
           - python-version: '3.10'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', 'pypy3']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', 'pypy-3.8']
         django-version: ['2.2', '3.0', '3.1', '3.2', '4.0', 'main']
         exclude:
           - python-version: '3.6'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,11 @@ jobs:
       matrix:
         python-version: ['3.6', '3.7', '3.8', '3.9', 'pypy3']
         django-version: ['2.2', '3.0', '3.1', '3.2', 'main']
+        exclude:
+          - python-version: '3.6'
+            django-version: 'main'
+          - python-version: '3.7'
+            django-version: 'main'
 
     steps:
     - uses: actions/checkout@v2

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
   pypy3-dj{22,30,31}
   py{36,37,38,39}-dj{22,30,31,32}
-  py{38,39}-djmain
+  py{38,39,310}-djmain
   docs
 
 [gh-actions]
@@ -11,6 +11,7 @@ python =
     3.7: py37
     3.8: py38, docs
     3.9: py39
+    3.10: py310
     pypy3: pypy3
 
 [gh-actions:env]
@@ -28,6 +29,7 @@ basepython =
   py37: python3.7
   py38: python3.8
   py39: python3.9
+  py310: python3.10
 deps =
   pypy3: mock
   dj22: Django>=2.2.1,<2.3

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
   pypy3-dj{22,30,31}
   py{36,37,38,39}-dj{22,30,31,32}
-  py{38,39,310}-djmain
+  py{38,39,310}-dj{40,main}
   docs
 
 [gh-actions]
@@ -20,6 +20,7 @@ DJANGO =
     3.0: dj30
     3.1: dj31
     3.2: dj32
+    4.0: dj40
     main: djmain
 
 [testenv]
@@ -36,6 +37,7 @@ deps =
   dj30: Django>=3.0,<3.1
   dj31: Django>=3.1,<3.2
   dj32: Django>=3.2,<3.3
+  dj40: Django>=4.0.0a1,<4.1
   djmain: https://github.com/django/django/archive/main.tar.gz
   jinja2
   coverage
@@ -53,8 +55,10 @@ commands =
     {envbindir}/coverage xml
 whitelist_externals = npm
 ignore_outcome =
+    dj40: True
     djmain: True
 ignore_errors =
+    dj40: True
     djmain: True
 
 [testenv:docs]


### PR DESCRIPTION
See the individual commits, but basically this PR improves the Python/Django version testing matrix by:

- Ensure we're not testing unsupported Python/Django combinations (eg. Django's `main` branch doesn't need to be tested against Python 3.6 since the [minimum supported version is 3.8](https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django))
- Start testing Django's `main` and `4.0.x` branch against Python 3.10
- Separately test Django `4.0.x` from it's `main` branch (since they have now diverged)
- Merged in change from #761 changing the deprecated `pypy3` to `pypy-3.8`

Currently `django-pipeline` fails against the `4.0.x` and `main` branch, I'm going to push a separate PR (#760) which should fix all the issues (and remove `dj40` from tox's `ignore_outcome`) meaning this package should be ready for Django 4.0 support as soon as its [released next month](https://code.djangoproject.com/wiki/Version4.0Roadmap).

