### PR TITLE
docs: Fix a few typos

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -31,7 +31,7 @@ tox and django installed::
     python3.7 -m pip install tox
 
 Since we use a number of node.js tools, one should first install the node
-depencies. We reccomend using [nvm](https://github.com/nvm-sh/nvm#installation-and-update) , tl;dr::
+dependencies. We recommend using [nvm](https://github.com/nvm-sh/nvm#installation-and-update) , tl;dr::
 
     curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.2/install.sh | bash
     nvm install node

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -16,7 +16,7 @@ For their internal tools: http://www.20minutes.fr
 Borsala
 -------
 
-Borsala is the social investment plaform. You can follow stock markets that are traded in Turkey: http://borsala.com
+Borsala is the social investment platform. You can follow stock markets that are traded in Turkey: http://borsala.com
 
 
 Croisé dans le Métro


### PR DESCRIPTION
There are small typos in:
- CONTRIBUTING.rst
- docs/using.rst

Fixes:
- Should read `recommend` rather than `reccomend`.
- Should read `platform` rather than `plaform`.
- Should read `dependencies` rather than `depencies`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md