### PR TITLE
swapped the project_infile path with the infile path on the compile_f…

### DIFF
--- a/pipeline/compilers/__init__.py
+++ b/pipeline/compilers/__init__.py
@@ -35,7 +35,7 @@ class Compiler(object):
                     project_infile = finders.find(input_path)
                     outfile = compiler.output_path(infile, compiler.output_extension)
                     outdated = compiler.is_outdated(project_infile, outfile)
-                    compiler.compile_file(project_infile, outfile,
+                    compiler.compile_file(infile, outfile,
                                           outdated=outdated, force=force,
                                           **compiler_options)
 


### PR DESCRIPTION
collectstatic static fails with the project_infile variable in the compile_file method because the finder looks for static files in the static directories not from static_root. 