### PR TITLE
Add Django 4.1 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,14 +10,18 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', 'pypy-3.8']
-        django-version: ['2.2', '3.0', '3.1', '3.2', '4.0', 'main']
+        django-version: ['2.2', '3.0', '3.1', '3.2', '4.0', '4.1', 'main']
         exclude:
           - python-version: '3.6'
             django-version: '4.0'
           - python-version: '3.6'
+            django-version: '4.1'
+          - python-version: '3.6'
             django-version: 'main'
           - python-version: '3.7'
             django-version: '4.0'
+          - python-version: '3.7'
+            django-version: '4.1'
           - python-version: '3.7'
             django-version: 'main'
           - python-version: 'pypy-3.8'

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,8 @@ History
 Unreleased
 ==========
 
+* Added **Django 4.1** compatibility
+
 2.0.8
 =====
 

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         'Framework :: Django :: 3.1',
         'Framework :: Django :: 3.2',
         'Framework :: Django :: 4.0',
+        'Framework :: Django :: 4.1',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',

--- a/tests/tests/test_forms.py
+++ b/tests/tests/test_forms.py
@@ -75,7 +75,7 @@ class PipelineFormMediaTests(TestCase):
             })
         self.assertEqual(MyMedia.css, media._css)
         expected_regex = [
-            r'<link href="%s" type="text/css" media="all" '
+            r'<link href="%s" (type="text/css" )?media="all" '
             'rel="stylesheet"( /)?>' % path
             for path in (
                 '/static/extra1.css',
@@ -84,7 +84,7 @@ class PipelineFormMediaTests(TestCase):
                 '/static/styles2.min.css',
             )
         ] + [
-            r'<link href="/static/print.min.css" type="text/css" '
+            r'<link href="/static/print.min.css" (type="text/css" )?'
             'media="print" rel="stylesheet"( /)?>'
         ]
         for rendered_node, expected_node in zip(
@@ -122,7 +122,7 @@ class PipelineFormMediaTests(TestCase):
         self.assertEqual(MyMedia.css, media._css)
 
         expected_regex = [
-            '<link href="%s" type="text/css" media="all" '
+            '<link href="%s" (type="text/css" )?media="all" '
             'rel="stylesheet"( /)?>' % path
             for path in (
                 '/static/extra1.css',
@@ -132,7 +132,7 @@ class PipelineFormMediaTests(TestCase):
                 '/static/pipeline/css/unicode.css',
             )
         ] + [
-            '<link href="/static/pipeline/css/urls.css" type="text/css" '
+            '<link href="/static/pipeline/css/urls.css" (type="text/css" )?'
             'media="print" rel="stylesheet"( /)?>'
         ]
         for rendered_node, expected_node in zip(

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
   pypy3-dj{22,30,31,32}
   py{36,37,38,39}-dj{22,30,31}
   py{36,37,38,39,10}-dj32
-  py{38,39,310}-dj{40,main}
+  py{38,39,310}-dj{40,41,main}
   docs
 
 [gh-actions]
@@ -22,6 +22,7 @@ DJANGO =
     3.1: dj31
     3.2: dj32
     4.0: dj40
+    4.1: dj41
     main: djmain
 
 [testenv]
@@ -39,6 +40,7 @@ deps =
   dj31: Django>=3.1,<3.2
   dj32: Django>=3.2,<3.3
   dj40: Django>=4.0,<4.1
+  dj41: Django>=4.1,<4.2
   djmain: https://github.com/django/django/archive/main.tar.gz
   jinja2
   coverage


### PR DESCRIPTION
Only a small change was required in the tests to handle [this change](https://github.com/django/django/pull/15344) about removing the `type="text/css"` attributes for [CSS link tags](https://docs.djangoproject.com/en/4.1/topics/forms/media/#css):

![2022-09-29_12-14](https://user-images.githubusercontent.com/1423728/193122207-db30b095-75a5-4240-aab5-784db1a1c39e.png)

---

It might make sense when releasing a new version to drop support for Python 3.6 and Django 2.2, 3.0 and 3.1 since they have all reached end of life. If you want I can push that in this PR or seperately