### PR TITLE
Remove Python 3.6 from tox and setup.py

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -90,6 +90,7 @@ or just made Pipeline more awesome.
  * Nathan Shafer <nate@torzo.com>
  * Patrick Altman <paltman@gmail.com>
  * Peter Baumgartner <pete@lincolnloop.com>
+ * Peyman Salehi <slh.peyman@gmail.com>
  * Philipp Wollermann <philipp.wollermann@gmail.com>
  * Pierre Drescher <pierre.drescher@gmail.com>
  * Rajiv Bose <nerd.bose@gmail.com>

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,13 @@
 [tox]
 envlist =
   pypy3-dj{22,30,31,32}
-  py{36,37,38,39}-dj{22,30,31}
-  py{36,37,38,39,10}-dj32
+  py{37,38,39}-dj{22,30,31}
+  py{37,38,39,10}-dj32
   py{38,39,310}-dj{40,main}
   docs
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38, docs
     3.9: py39
@@ -27,7 +26,6 @@ DJANGO =
 [testenv]
 basepython =
   pypy3: pypy3
-  py36: python3.6
   py37: python3.7
   py38: python3.8
   py39: python3.9


### PR DESCRIPTION
In these two commits, we dropped Python 3.6 from GitHub action. [link1](https://github.com/jazzband/django-pipeline/commit/d4ab608597ab5f918575dc2f4239faa9d3a57fe5) [link2](https://github.com/jazzband/django-pipeline/commit/fa5aea3e4ca1b2b991b682ad20f1aa23f180d9a2)
But it was still in `tox` and `setup.py` files.
