### PR TITLE
Add npm package-lock.json to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ tests/npm-cache
 django-pipeline-*/
 .tags
 node_modules/
+package-lock.json


### PR DESCRIPTION
When running tests locally npm creates a `package-lock.json` to lock the package's version, and because creates it in the root directory and we are using it for testing only I put it in the `.gitignore` file.