### PR TITLE
Add TypeScript compiler support

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ Unreleased
 ==========
 
 * Update README.rst and add Pipeline overview image
+* Add TypeScript compiler support
 
 
 2.0.9

--- a/docs/compilers.rst
+++ b/docs/compilers.rst
@@ -4,6 +4,32 @@
 Compilers
 =========
 
+TypeScript compiler
+======================
+
+The TypeScript compiler uses `TypeScript <https://www.typescriptlang.org/>`_
+to compile your TypeScript code to JavaScript.
+
+To use it add this to your ``PIPELINE['COMPILERS']`` ::
+
+  PIPELINE['COMPILERS'] = (
+    'pipeline.compilers.typescript.TypeScriptCompiler',
+  )
+
+``TYPE_SCRIPT_BINARY``
+---------------------------------
+
+  Command line to execute for TypeScript program.
+  You will most likely change this to the location of ``tsc`` on your system.
+
+  Defaults to ``'/usr/bin/env tsc'``.
+
+``TYPE_SCRIPT_ARGUMENTS``
+------------------------------------
+
+  Additional arguments to use when ``tsc`` is called.
+
+  Defaults to ``''``.
 
 Coffee Script compiler
 ======================

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "terser": "latest",
     "uglify-js": "latest",
     "yuglify": "1.0.x",
-    "yuicompressor": "latest"
+    "yuicompressor": "latest",
+    "typescript": "latest"
   }
 }

--- a/pipeline/compilers/typescript.py
+++ b/pipeline/compilers/typescript.py
@@ -1,0 +1,21 @@
+from pipeline.compilers import SubProcessCompiler
+from pipeline.conf import settings
+
+
+class TypeScriptCompiler(SubProcessCompiler):
+    output_extension = 'js'
+
+    def match_file(self, path):
+        return path.endswith('.ts')
+
+    def compile_file(self, infile, outfile, outdated=False, force=False):
+        if not outdated and not force:
+            return
+        command = (
+            settings.TYPE_SCRIPT_BINARY,
+            settings.TYPE_SCRIPT_ARGUMENTS,
+            infile,
+            '--outFile',
+            outfile,
+        )
+        return self.execute_command(command)

--- a/pipeline/conf.py
+++ b/pipeline/conf.py
@@ -63,6 +63,9 @@ DEFAULTS = {
     'LIVE_SCRIPT_BINARY': '/usr/bin/env lsc',
     'LIVE_SCRIPT_ARGUMENTS': '',
 
+    'TYPE_SCRIPT_BINARY': '/usr/bin/env tsc',
+    'TYPE_SCRIPT_ARGUMENTS': '',
+
     'SASS_BINARY': '/usr/bin/env sass',
     'SASS_ARGUMENTS': '',
 
@@ -76,6 +79,7 @@ DEFAULTS = {
         (('text/coffeescript'), ('.coffee')),
         (('text/less'), ('.less')),
         (('text/javascript'), ('.js')),
+        (('text/typescript'), ('.ts')),
         (('text/x-sass'), ('.sass')),
         (('text/x-scss'), ('.scss'))
     ),

--- a/tests/assets/compilers/typescript/expected.js
+++ b/tests/assets/compilers/typescript/expected.js
@@ -1,0 +1,4 @@
+function getName(u) {
+    return "".concat(u.firstName, " ").concat(u.lastName);
+}
+var userName = getName({ firstName: "Django", lastName: "Pipeline" });

--- a/tests/assets/compilers/typescript/input.ts
+++ b/tests/assets/compilers/typescript/input.ts
@@ -1,0 +1,13 @@
+type FullName = string;
+
+interface User {
+    firstName: string;
+    lastName: string;
+}
+
+
+function getName(u: User): FullName {
+    return `${u.firstName} ${u.lastName}`;
+}
+
+let userName: FullName = getName({firstName: "Django", lastName: "Pipeline"});

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -173,6 +173,7 @@ if HAS_NODE:
         'UGLIFYJS_BINARY': node_exe_path('uglifyjs'),
         'TERSER_BINARY': node_exe_path('terser'),
         'CSSMIN_BINARY': node_exe_path('cssmin'),
+        'TYPE_SCRIPT_BINARY': node_exe_path('tsc'),
     })
 
 if HAS_NODE and HAS_JAVA:

--- a/tests/tests/test_compiler.py
+++ b/tests/tests/test_compiler.py
@@ -276,6 +276,13 @@ class CompilerImplementation(TestCase):
             'pipeline/compilers/es6/expected.js',
         )
 
+    def test_typescript(self):
+        self._test_compiler(
+            'pipeline.compilers.typescript.TypeScriptCompiler',
+            'pipeline/compilers/typescript/input.ts',
+            'pipeline/compilers/typescript/expected.js',
+        )
+
     def test_stylus(self):
         self._test_compiler(
             'pipeline.compilers.stylus.StylusCompiler',


### PR DESCRIPTION
TypeScript is used more frequently these days and I thought it could be a good feature for Pipeline to support its compiler.
- Add TypeScript compiler support
- Add test for TypeScript Compiler
- Update compilers documentation
- Update HISTORY.rst