### PR TITLE
Upgrade syntax to Python 3 using `pyupgrade`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,8 +37,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'django-pipeline'
-copyright = u'2011-2014, Timothée Peignier'
+project = 'django-pipeline'
+copyright = '2011-2014, Timothée Peignier'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -175,8 +175,8 @@ htmlhelp_basename = 'django-pipelinedoc'
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'django-pipeline.tex', u'Pipeline Documentation',
-   u'Timothée Peignier', 'manual'),
+  ('index', 'django-pipeline.tex', 'Pipeline Documentation',
+   'Timothée Peignier', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -208,6 +208,6 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'django-pipeline', u'Pipeline Documentation',
-     [u'Timothée Peignier'], 1)
+    ('index', 'django-pipeline', 'Pipeline Documentation',
+     ['Timothée Peignier'], 1)
 ]

--- a/pipeline/collector.py
+++ b/pipeline/collector.py
@@ -8,7 +8,7 @@ from django.contrib.staticfiles.storage import staticfiles_storage
 from pipeline.finders import PipelineFinder
 
 
-class Collector(object):
+class Collector:
     request = None
 
     def __init__(self, storage=None):

--- a/pipeline/compilers/__init__.py
+++ b/pipeline/compilers/__init__.py
@@ -13,7 +13,7 @@ from pipeline.exceptions import CompilerError
 from pipeline.utils import set_std_streams_blocking, to_class
 
 
-class Compiler(object):
+class Compiler:
     def __init__(self, storage=None, verbose=False):
         if storage is None:
             storage = staticfiles_storage
@@ -56,7 +56,7 @@ class Compiler(object):
                 return list(executor.map(_compile, paths))
 
 
-class CompilerBase(object):
+class CompilerBase:
     def __init__(self, verbose, storage):
         self.verbose = verbose
         self.storage = storage

--- a/pipeline/compressors/__init__.py
+++ b/pipeline/compressors/__init__.py
@@ -34,7 +34,7 @@ EMBED_EXTS = MIME_TYPES.keys()
 FONT_EXTS = ['.ttf', '.otf', '.woff']
 
 
-class Compressor(object):
+class Compressor:
     asset_contents = {}
 
     def __init__(self, storage=None, verbose=False):
@@ -90,7 +90,7 @@ class Compressor(object):
             contents = re.sub("\r?\n", "\\\\n", contents)
             contents = re.sub("'", "\\'", contents)
             name = self.template_name(path, base_path)
-            compiled.append("%s['%s'] = %s('%s');\n" % (
+            compiled.append("{}['{}'] = {}('{}');\n".format(
                 namespace,
                 name,
                 settings.TEMPLATE_FUNC,
@@ -101,7 +101,7 @@ class Compressor(object):
         else:
             compiler = ""
         return "\n".join([
-            "%(namespace)s = %(namespace)s || {};" % {'namespace': namespace},
+            "{namespace} = {namespace} || {{}};".format(namespace=namespace),
             compiler,
             ''.join(compiled)
         ])
@@ -118,7 +118,7 @@ class Compressor(object):
             path = os.path.basename(path)
         if path == base:
             base = os.path.dirname(path)
-        name = re.sub(r"^%s[\/\\]?(.*)%s$" % (
+        name = re.sub(r"^{}[\/\\]?(.*){}$".format(
             re.escape(base), re.escape(settings.TEMPLATE_EXT)
         ), r"\1", path)
         return re.sub(r"[\/\\]", settings.TEMPLATE_SEPARATOR, name)
@@ -228,7 +228,7 @@ class Compressor(object):
         return force_str(content)
 
 
-class CompressorBase(object):
+class CompressorBase:
     def __init__(self, verbose):
         self.verbose = verbose
 

--- a/pipeline/compressors/terser.py
+++ b/pipeline/compressors/terser.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from pipeline.compressors import SubProcessCompressor
 from pipeline.conf import settings
 

--- a/pipeline/exceptions.py
+++ b/pipeline/exceptions.py
@@ -1,5 +1,3 @@
-
-
 class PipelineException(Exception):
     pass
 
@@ -10,7 +8,7 @@ class PackageNotFound(PipelineException):
 
 class CompilerError(PipelineException):
     def __init__(self, msg, command=None, error_output=None):
-        super(CompilerError, self).__init__(msg)
+        super().__init__(msg)
 
         self.command = command
         self.error_output = error_output.strip()

--- a/pipeline/finders.py
+++ b/pipeline/finders.py
@@ -18,7 +18,7 @@ class PipelineFinder(BaseStorageFinder):
 
     def find(self, path, all=False):
         if not settings.PIPELINE_ENABLED:
-            return super(PipelineFinder, self).find(path, all)
+            return super().find(path, all)
         else:
             return []
 
@@ -60,7 +60,7 @@ class CachedFileFinder(BaseFinder):
         return []
 
 
-class PatternFilterMixin(object):
+class PatternFilterMixin:
     ignore_patterns = []
 
     def get_ignored_patterns(self):
@@ -69,7 +69,7 @@ class PatternFilterMixin(object):
     def list(self, ignore_patterns):
         if ignore_patterns:
             ignore_patterns = ignore_patterns + self.get_ignored_patterns()
-        return super(PatternFilterMixin, self).list(ignore_patterns)
+        return super().list(ignore_patterns)
 
 
 class AppDirectoriesFinder(PatternFilterMixin, DjangoAppDirectoriesFinder):

--- a/pipeline/forms.py
+++ b/pipeline/forms.py
@@ -8,7 +8,7 @@ from .conf import settings
 from .packager import Packager
 
 
-class PipelineFormMediaProperty(object):
+class PipelineFormMediaProperty:
     """A property that converts Pipeline packages to lists of files.
 
     This is used behind the scenes for any Media classes that subclass
@@ -122,7 +122,7 @@ class PipelineFormMediaMetaClass(type):
             type:
             The new class.
         """
-        new_class = super(PipelineFormMediaMetaClass, cls).__new__(
+        new_class = super().__new__(
             cls, name, bases, attrs)
 
         # If we define any packages, we'll need to use our special
@@ -158,15 +158,15 @@ class PipelineFormMediaMetaClass(type):
         packager = Packager()
         css_packages = getattr(cls, 'css_packages', {})
 
-        return dict(
-            (media_target,
-             cls._get_media_files(packager=packager,
-                                  media_packages=media_packages,
-                                  media_type='css',
-                                  extra_files=extra_files.get(media_target,
-                                                              [])))
+        return {
+            media_target: cls._get_media_files(
+                packager=packager,
+                media_packages=media_packages,
+                media_type='css',
+                extra_files=extra_files.get(media_target, []),
+            )
             for media_target, media_packages in css_packages.items()
-        )
+        }
 
     def _get_js_files(cls, extra_files):
         """Return all JavaScript files from the Media class.
@@ -229,7 +229,7 @@ class PipelineFormMediaMetaClass(type):
         return source_files
 
 
-class PipelineFormMedia(object, metaclass=PipelineFormMediaMetaClass):
+class PipelineFormMedia(metaclass=PipelineFormMediaMetaClass):
     """Base class for form or widget Media classes that use Pipeline packages.
 
     Forms or widgets that need custom CSS or JavaScript media on a page can

--- a/pipeline/jinja2/__init__.py
+++ b/pipeline/jinja2/__init__.py
@@ -8,7 +8,7 @@ from ..utils import guess_type
 
 
 class PipelineExtension(PipelineMixin, Extension):
-    tags = set(['stylesheet', 'javascript'])
+    tags = {'stylesheet', 'javascript'}
 
     def parse(self, parser):
         tag = next(parser.stream)

--- a/pipeline/middleware.py
+++ b/pipeline/middleware.py
@@ -8,7 +8,7 @@ from pipeline.conf import settings
 
 class MinifyHTMLMiddleware(MiddlewareMixin):
     def __init__(self, *args, **kwargs):
-        super(MinifyHTMLMiddleware, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         if not settings.PIPELINE_ENABLED:
             raise MiddlewareNotUsed
 

--- a/pipeline/packager.py
+++ b/pipeline/packager.py
@@ -11,7 +11,7 @@ from pipeline.glob import glob
 from pipeline.signals import css_compressed, js_compressed
 
 
-class Package(object):
+class Package:
     def __init__(self, config):
         self.config = config
         self._sources = []
@@ -62,7 +62,7 @@ class Package(object):
         return self.config.get('compiler_options', {})
 
 
-class Packager(object):
+class Packager:
     def __init__(
         self,
         storage=None,
@@ -90,7 +90,7 @@ class Packager(object):
             return self.packages[kind][package_name]
         except KeyError:
             raise PackageNotFound(
-                "No corresponding package for %s package name : %s" % (
+                "No corresponding package for {} package name : {}".format(
                     kind, package_name
                 )
             )
@@ -125,7 +125,7 @@ class Packager(object):
                             print("Saving: %s" % path)
                         self.storage.save(path, source_file)
                 else:
-                    raise IOError("File does not exist: %s" % path)
+                    raise OSError("File does not exist: %s" % path)
         return paths
 
     def pack(self, package, compress, signal, **kwargs):

--- a/pipeline/storage.py
+++ b/pipeline/storage.py
@@ -13,7 +13,7 @@ if _CACHED_STATIC_FILES_STORAGE_AVAILABLE:
     from django.contrib.staticfiles.storage import CachedStaticFilesStorage
 
 
-class PipelineMixin(object):
+class PipelineMixin:
     packing = True
 
     def post_process(self, paths, dry_run=False, **options):
@@ -37,12 +37,11 @@ class PipelineMixin(object):
             paths[output_file] = (self, output_file)
             yield output_file, output_file, True
 
-        super_class = super(PipelineMixin, self)
+        super_class = super()
         if hasattr(super_class, 'post_process'):
-            for name, hashed_name, processed in super_class.post_process(
+            yield from super_class.post_process(
                 paths.copy(), dry_run, **options
-            ):
-                yield name, hashed_name, processed
+            )
 
     def get_available_name(self, name, max_length=None):
         if self.exists(name):
@@ -50,7 +49,7 @@ class PipelineMixin(object):
         return name
 
 
-class GZIPMixin(object):
+class GZIPMixin:
     gzip_patterns = ("*.css", "*.js")
 
     def _compress(self, original_file):
@@ -62,7 +61,7 @@ class GZIPMixin(object):
         return File(content)
 
     def post_process(self, paths, dry_run=False, **options):
-        super_class = super(GZIPMixin, self)
+        super_class = super()
         if hasattr(super_class, 'post_process'):
             for name, hashed_name, processed in super_class.post_process(
                 paths.copy(), dry_run, **options
@@ -87,7 +86,7 @@ class GZIPMixin(object):
                 yield gzipped_path, gzipped_path, True
 
 
-class NonPackagingMixin(object):
+class NonPackagingMixin:
     packing = False
 
 

--- a/pipeline/templatetags/pipeline.py
+++ b/pipeline/templatetags/pipeline.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 register = template.Library()
 
 
-class PipelineMixin(object):
+class PipelineMixin:
     request = None
     _request_var = None
 
@@ -124,7 +124,7 @@ class StylesheetNode(PipelineMixin, template.Node):
         self.name = name
 
     def render(self, context):
-        super(StylesheetNode, self).render(context)
+        super().render(context)
         package_name = template.Variable(self.name).resolve(context)
 
         try:
@@ -150,7 +150,7 @@ class StylesheetNode(PipelineMixin, template.Node):
         return '\n'.join(tags)
 
     def render_error_css(self, package_name, e):
-        return super(StylesheetNode, self).render_error(
+        return super().render_error(
             'CSS', package_name, e)
 
 
@@ -159,7 +159,7 @@ class JavascriptNode(PipelineMixin, template.Node):
         self.name = name
 
     def render(self, context):
-        super(JavascriptNode, self).render(context)
+        super().render(context)
         package_name = template.Variable(self.name).resolve(context)
 
         try:
@@ -194,7 +194,7 @@ class JavascriptNode(PipelineMixin, template.Node):
         return '\n'.join(tags)
 
     def render_error_js(self, package_name, e):
-        return super(JavascriptNode, self).render_error(
+        return super().render_error(
             'JavaScript', package_name, e)
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-import io
-
 from setuptools import find_packages, setup
 
 setup(
@@ -9,8 +6,8 @@ setup(
     setup_requires=["setuptools_scm"],
     description='Pipeline is an asset packaging library for Django.',
     long_description=(
-        io.open('README.rst', encoding='utf-8').read() + '\n\n' +
-        io.open('HISTORY.rst', encoding='utf-8').read()
+        open('README.rst', encoding='utf-8').read() + '\n\n' +
+        open('HISTORY.rst', encoding='utf-8').read()
     ),
     author='Timothée Peignier',
     author_email='timothee.peignier@tryphon.org',

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -157,7 +157,7 @@ HAS_CSSTIDY = bool(CSSTIDY_EXE_PATH)
 if HAS_NODE:
     def node_exe_path(command):
         exe_ext = '.cmd' if os.name == 'nt' else ''
-        return os.path.join(NODE_BIN_PATH, "%s%s" % (command, exe_ext))
+        return os.path.join(NODE_BIN_PATH, "{}{}".format(command, exe_ext))
 
     PIPELINE.update({
         'SASS_BINARY': node_exe_path('node-sass'),

--- a/tests/tests/test_collector.py
+++ b/tests/tests/test_collector.py
@@ -14,7 +14,7 @@ def local_path(path):
 
 class CollectorTest(TestCase):
     def tearDown(self):
-        super(CollectorTest, self).tearDown()
+        super().tearDown()
 
         default_collector.clear()
 
@@ -29,10 +29,10 @@ class CollectorTest(TestCase):
                 'pipeline/js/first.js',
                 'pipeline/js/second.js',
             ])),
-            set([
+            {
                 'pipeline/js/first.js',
                 'pipeline/js/second.js',
-            ]))
+            })
 
     def test_delete_file_with_modified(self):
         list(default_collector.collect())

--- a/tests/tests/test_compiler.py
+++ b/tests/tests/test_compiler.py
@@ -242,7 +242,7 @@ class CompilerImplementation(TestCase):
         infile_path = staticfiles_storage.path(infile)
         outfile_path = compiler.output_path(infile_path, compiler.output_extension)
         compiler.compile_file(_(infile_path), _(outfile_path), force=True)
-        with open(outfile_path, 'r') as f:
+        with open(outfile_path) as f:
             result = f.read()
         with staticfiles_storage.open(expected, 'r') as f:
             expected = f.read()

--- a/tests/tests/test_compressor.py
+++ b/tests/tests/test_compressor.py
@@ -1,10 +1,9 @@
 import base64
-import io
 import os
 import sys
 
 try:
-    from mock import patch
+    from unittest.mock import patch
 except ImportError:
     from unittest.mock import patch  # noqa
 
@@ -97,7 +96,7 @@ class CompressorTest(TestCase):
         name = self.compressor.template_name('templates/photo_edit.jst', '')
         self.assertEqual(name, 'photo_edit')
         name = self.compressor.template_name(
-            'templates\photo\detail.jst', # noqa
+            r'templates\photo\detail.jst', # noqa
             'templates\\',
         )
         self.assertEqual(name, 'photo_detail')
@@ -110,7 +109,7 @@ class CompressorTest(TestCase):
         name = self.compressor.template_name('templates/photo_edit.jst', '')
         self.assertEqual(name, 'photo_edit')
         name = self.compressor.template_name(
-            'templates\photo\detail.jst', # noqa
+            r'templates\photo\detail.jst', # noqa
             'templates\\',
         )
         self.assertEqual(name, 'photo/detail')
@@ -201,7 +200,7 @@ class CompressorTest(TestCase):
     @skipIf(sys.platform.startswith("win"), "requires posix platform")
     def test_compressor_subprocess_unicode(self):
         path = os.path.dirname(os.path.dirname(__file__))
-        content = io.open(path + '/assets/css/unicode.css', encoding="utf-8").read()
+        content = open(path + '/assets/css/unicode.css', encoding="utf-8").read()
         output = SubProcessCompressor(False).execute_command(('cat',), content)
         self.assertEqual(""".some_class {
   // Some unicode

--- a/tests/tests/test_conf.py
+++ b/tests/tests/test_conf.py
@@ -12,7 +12,7 @@ class TestSettings(TestCase):
         self.assertEqual(s.FOO_BINARY, ('env', 'actualprogram'))
 
     def test_2unicode(self):
-        s = PipelineSettings({"FOO_BINARY": u"env actualprogram"})
+        s = PipelineSettings({"FOO_BINARY": "env actualprogram"})
         self.assertEqual(s.FOO_BINARY, ('env', 'actualprogram'))
 
     def test_2bytes(self):

--- a/tests/tests/test_template.py
+++ b/tests/tests/test_template.py
@@ -12,50 +12,50 @@ class JinjaTest(TestCase):
                                loader=PackageLoader('pipeline', 'templates'))
 
     def test_no_package(self):
-        template = self.env.from_string(u"""{% stylesheet "unknow" %}""")
-        self.assertEqual(u'', template.render())
-        template = self.env.from_string(u"""{% javascript "unknow" %}""")
-        self.assertEqual(u'', template.render())
+        template = self.env.from_string("""{% stylesheet "unknow" %}""")
+        self.assertEqual('', template.render())
+        template = self.env.from_string("""{% javascript "unknow" %}""")
+        self.assertEqual('', template.render())
 
     def test_package_css(self):
-        template = self.env.from_string(u"""{% stylesheet "screen" %}""")
+        template = self.env.from_string("""{% stylesheet "screen" %}""")
         self.assertEqual(
-            u'<link href="/static/screen.css" rel="stylesheet" type="text/css" />',
+            '<link href="/static/screen.css" rel="stylesheet" type="text/css" />',
             template.render(),
         )
 
     @pipeline_settings(PIPELINE_ENABLED=False)
     def test_package_css_disabled(self):
-        template = self.env.from_string(u"""{% stylesheet "screen" %}""")
-        self.assertEqual(u'''<link href="/static/pipeline/css/first.css" rel="stylesheet" type="text/css" />
+        template = self.env.from_string("""{% stylesheet "screen" %}""")
+        self.assertEqual('''<link href="/static/pipeline/css/first.css" rel="stylesheet" type="text/css" />
 <link href="/static/pipeline/css/second.css" rel="stylesheet" type="text/css" />
 <link href="/static/pipeline/css/urls.css" rel="stylesheet" type="text/css" />''', template.render()) # noqa
 
     def test_package_js(self):
-        template = self.env.from_string(u"""{% javascript "scripts" %}""")
+        template = self.env.from_string("""{% javascript "scripts" %}""")
         self.assertEqual(
-            u'<script type="text/javascript" src="/static/scripts.js" charset="utf-8"></script>', # noqa
+            '<script type="text/javascript" src="/static/scripts.js" charset="utf-8"></script>', # noqa
             template.render(),
         )
 
     def test_package_js_async(self):
-        template = self.env.from_string(u"""{% javascript "scripts_async" %}""")
+        template = self.env.from_string("""{% javascript "scripts_async" %}""")
         self.assertEqual(
-            u'<script async type="text/javascript" src="/static/scripts_async.js" charset="utf-8"></script>', # noqa
+            '<script async type="text/javascript" src="/static/scripts_async.js" charset="utf-8"></script>', # noqa
             template.render(),
         )
 
     def test_package_js_defer(self):
-        template = self.env.from_string(u"""{% javascript "scripts_defer" %}""")
+        template = self.env.from_string("""{% javascript "scripts_defer" %}""")
         self.assertEqual(
-            u'<script defer type="text/javascript" src="/static/scripts_defer.js" charset="utf-8"></script>', # noqa
+            '<script defer type="text/javascript" src="/static/scripts_defer.js" charset="utf-8"></script>', # noqa
             template.render(),
         )
 
     def test_package_js_async_defer(self):
-        template = self.env.from_string(u"""{% javascript "scripts_async_defer" %}""")
+        template = self.env.from_string("""{% javascript "scripts_async_defer" %}""")
         self.assertEqual(
-            u'<script async defer type="text/javascript" src="/static/scripts_async_defer.js" charset="utf-8"></script>', # noqa
+            '<script async defer type="text/javascript" src="/static/scripts_async_defer.js" charset="utf-8"></script>', # noqa
             template.render(),
         )
 
@@ -66,69 +66,69 @@ class DjangoTest(TestCase):
 
     def test_compressed_empty(self):
         rendered = self.render_template(
-            u"""{% load pipeline %}{% stylesheet "unknow" %}""",
+            """{% load pipeline %}{% stylesheet "unknow" %}""",
         )
-        self.assertEqual(u'', rendered)
+        self.assertEqual('', rendered)
 
     def test_compressed_css(self):
         rendered = self.render_template(
-            u"""{% load pipeline %}{% stylesheet "screen" %}""",
+            """{% load pipeline %}{% stylesheet "screen" %}""",
         )
         self.assertEqual(
-            u'<link href="/static/screen.css" rel="stylesheet" type="text/css" media="all" />', # noqa
+            '<link href="/static/screen.css" rel="stylesheet" type="text/css" media="all" />', # noqa
             rendered,
         )
 
     def test_compressed_css_media(self):
         rendered = self.render_template(
-            u"""{% load pipeline %}{% stylesheet "screen_media" %}""",
+            """{% load pipeline %}{% stylesheet "screen_media" %}""",
         )
         self.assertEqual(
-            u'<link href="/static/screen_media.css" rel="stylesheet" type="text/css" media="screen and (min-width:500px)" />', # noqa
+            '<link href="/static/screen_media.css" rel="stylesheet" type="text/css" media="screen and (min-width:500px)" />', # noqa
             rendered,
         )
 
     def test_compressed_css_title(self):
         rendered = self.render_template(
-            u"""{% load pipeline %}{% stylesheet "screen_title" %}""",
+            """{% load pipeline %}{% stylesheet "screen_title" %}""",
         )
         self.assertEqual(
-            u'<link href="/static/screen_title.css" rel="stylesheet" type="text/css" media="all" title="Default Style" />', # noqa
+            '<link href="/static/screen_title.css" rel="stylesheet" type="text/css" media="all" title="Default Style" />', # noqa
             rendered,
         )
 
     def test_compressed_js(self):
         rendered = self.render_template(
-            u"""{% load pipeline %}{% javascript "scripts" %}""",
+            """{% load pipeline %}{% javascript "scripts" %}""",
         )
         self.assertEqual(
-            u'<script type="text/javascript" src="/static/scripts.js" charset="utf-8"></script>', # noqa
+            '<script type="text/javascript" src="/static/scripts.js" charset="utf-8"></script>', # noqa
             rendered,
         )
 
     def test_compressed_js_async(self):
         rendered = self.render_template(
-            u"""{% load pipeline %}{% javascript "scripts_async" %}""",
+            """{% load pipeline %}{% javascript "scripts_async" %}""",
         )
         self.assertEqual(
-            u'<script async type="text/javascript" src="/static/scripts_async.js" charset="utf-8"></script>', # noqa
+            '<script async type="text/javascript" src="/static/scripts_async.js" charset="utf-8"></script>', # noqa
             rendered,
         )
 
     def test_compressed_js_defer(self):
         rendered = self.render_template(
-            u"""{% load pipeline %}{% javascript "scripts_defer" %}""",
+            """{% load pipeline %}{% javascript "scripts_defer" %}""",
         )
         self.assertEqual(
-            u'<script defer type="text/javascript" src="/static/scripts_defer.js" charset="utf-8"></script>', # noqa
+            '<script defer type="text/javascript" src="/static/scripts_defer.js" charset="utf-8"></script>', # noqa
             rendered,
         )
 
     def test_compressed_js_async_defer(self):
         rendered = self.render_template(
-            u"""{% load pipeline %}{% javascript "scripts_async_defer" %}""",
+            """{% load pipeline %}{% javascript "scripts_async_defer" %}""",
         )
         self.assertEqual(
-            u'<script async defer type="text/javascript" src="/static/scripts_async_defer.js" charset="utf-8"></script>', # noqa
+            '<script async defer type="text/javascript" src="/static/scripts_async_defer.js" charset="utf-8"></script>', # noqa
             rendered,
         )

--- a/tests/tests/test_utils.py
+++ b/tests/tests/test_utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import mimetypes
 
 from django.test import TestCase

--- a/tests/tests/test_views.py
+++ b/tests/tests/test_views.py
@@ -13,7 +13,7 @@ from tests.utils import pipeline_settings
 @pipeline_settings(PIPELINE_COLLECTOR_ENABLED=True, PIPELINE_ENABLED=False)
 class ServeStaticViewsTest(TestCase):
     def setUp(self):
-        super(ServeStaticViewsTest, self).setUp()
+        super().setUp()
 
         self.filename = 'pipeline/js/first.js'
         self.storage = staticfiles_storage
@@ -22,7 +22,7 @@ class ServeStaticViewsTest(TestCase):
         default_collector.clear()
 
     def tearDown(self):
-        super(ServeStaticViewsTest, self).tearDown()
+        super().tearDown()
 
         default_collector.clear()
         staticfiles_storage._setup()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -15,5 +15,5 @@ class pipeline_settings(override_settings):
             # Django 1.10's override_settings inherits from TestContextDecorator
             # and its __init__ method calls its superclass' __init__ method too,
             # so we must do the same.
-            super(pipeline_settings, self).__init__()
+            super().__init__()
         self.options = {'PIPELINE': kwargs}


### PR DESCRIPTION
Using `pyupgrade` to upgrade old syntax to Python 3.
- docs/conf.py
- pipeline/*
- tests/*
- setup.py