### PR TITLE
avoid the use of pkg_resources when importlib.metadata is available

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,6 +14,7 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 # sys.path.insert(0, os.path.abspath('.'))
 from pipeline import __version__ as pipeline_version
+
 # -- General configuration -----------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,13 +8,12 @@
 #
 # All configuration values have a default; values that are commented out
 # serve to show the default.
-from pkg_resources import get_distribution
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 # sys.path.insert(0, os.path.abspath('.'))
-
+from pipeline import __version__ as pipeline_version
 # -- General configuration -----------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
@@ -45,7 +44,7 @@ copyright = "2011-2014, Timothée Peignier"
 # built documents.
 #
 # The full version, including alpha/beta/rc tags.
-release = get_distribution("django-pipeline").version
+release = pipeline_version
 # The short X.Y version.
 version = ".".join(release.split(".")[:2])
 

--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -1,24 +1,27 @@
 PackageNotFoundError = None
+DistributionNotFound = None
 try:
     from importlib.metadata import PackageNotFoundError
     from importlib.metadata import version as get_version
 except ImportError:
     get_version = None
-try:
-    from pkg_resources import DistributionNotFound as PackageNotFoundError
-    from pkg_resources import get_distribution
-
-
-    def get_version(x):
-        return get_distribution(x).version
-except ImportError:
-    get_version = None
     PackageNotFoundError = None
-    get_distribution = None
+if get_version is None:
+    try:
+        from pkg_resources import DistributionNotFound, get_distribution
+
+        def get_version(x):
+            return get_distribution(x).version
+    except ImportError:
+        get_version = None
+        DistributionNotFound = None
+        get_distribution = None
 
 __version__ = None
 if get_version is not None:
     try:
         __version__ = get_version("django-pipeline")
     except PackageNotFoundError:
+        pass
+    except DistributionNotFound:
         pass

--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -3,16 +3,18 @@ try:
     from importlib.metadata import PackageNotFoundError, version as get_version
 except ImportError:
     get_version = None
-try:
-    from pkg_resources import DistributionNotFound as PackageNotFoundError, get_distribution
+
+if get_version is None:
+    try:
+        from pkg_resources import DistributionNotFound as PackageNotFoundError, get_distribution
 
 
-    def get_version(x):
-        return get_distribution(x).version
-except ImportError:
-    get_version = None
-    PackageNotFoundError = None
-    get_distribution = None
+        def get_version(x):
+            return get_distribution(x).version
+    except ImportError:
+        get_version = None
+        PackageNotFoundError = None
+        get_distribution = None
 
 __version__ = None
 if get_version is not None:

--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -1,7 +1,22 @@
-from pkg_resources import DistributionNotFound, get_distribution
-
+PackageNotFoundError = None
 try:
-    __version__ = get_distribution("django-pipeline").version
-except DistributionNotFound:
-    # package is not installed
-    __version__ = None
+    from importlib.metadata import PackageNotFoundError, version as get_version
+except ImportError:
+    get_version = None
+try:
+    from pkg_resources import DistributionNotFound as PackageNotFoundError, get_distribution
+
+
+    def get_version(x):
+        return get_distribution(x).version
+except ImportError:
+    get_version = None
+    PackageNotFoundError = None
+    get_distribution = None
+
+__version__ = None
+if get_version is not None:
+    try:
+        __version__ = get_version("django-pipeline")
+    except PackageNotFoundError:
+        pass

--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -12,6 +12,7 @@ if get_version is None:
 
         def get_version(x):
             return get_distribution(x).version
+
     except ImportError:
         get_version = None
         DistributionNotFound = None

--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -1,20 +1,20 @@
 PackageNotFoundError = None
 try:
-    from importlib.metadata import PackageNotFoundError, version as get_version
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as get_version
 except ImportError:
     get_version = None
+try:
+    from pkg_resources import DistributionNotFound as PackageNotFoundError
+    from pkg_resources import get_distribution
 
-if get_version is None:
-    try:
-        from pkg_resources import DistributionNotFound as PackageNotFoundError, get_distribution
 
-
-        def get_version(x):
-            return get_distribution(x).version
-    except ImportError:
-        get_version = None
-        PackageNotFoundError = None
-        get_distribution = None
+    def get_version(x):
+        return get_distribution(x).version
+except ImportError:
+    get_version = None
+    PackageNotFoundError = None
+    get_distribution = None
 
 __version__ = None
 if get_version is not None:


### PR DESCRIPTION
pkg_resources is removed from Python 3.12, and its use raises a warning.
importlib.metadata can be used to get distribution info.