### PR TITLE
Add subresource integrity to script tag

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -123,6 +123,25 @@ Indicate if you want this group to appear in your cache manifest.
 
 Defaults to ``True``.
 
+``crossorigin``
+............
+
+**Optional**
+
+Indicate if you want to add to the group this attribute that provides support for CORS, defining how the element handles cross-origin requests, thereby enabling the configuration of the CORS requests for the element's fetched data. .
+
+Missing by default (the attribute is not added), the only valid values currently are ``anonymous`` and ``use-credentials``.
+
+``integrity``
+............
+
+**Optional**
+
+Indicate if you want to add the sub-resource integrity (SRI) attribute to the group.
+This attribute contains inline metadata that a user agent can use to verify that a fetched resource has been delivered free of unexpected manipulation
+
+Missing by default, and only valid values are ``"sha256"``, ``"sha384"`` and ``"sha512"``.
+
 ``compiler_options``
 ....................
 

--- a/pipeline/jinja2/__init__.py
+++ b/pipeline/jinja2/__init__.py
@@ -66,6 +66,8 @@ class PipelineExtension(PipelineMixin, Extension):
             {
                 "type": guess_type(path, "text/javascript"),
                 "url": staticfiles_storage.url(path),
+                "crossorigin": package.config.get("crossorigin"),
+                "integrity": package.get_sri(path),
             }
         )
         template = self.environment.get_template(template_name)

--- a/pipeline/jinja2/pipeline/js.jinja
+++ b/pipeline/jinja2/pipeline/js.jinja
@@ -1,1 +1,1 @@
-<script{% if async %} async{% endif %}{% if defer %} defer{% endif %} type="{{ type }}" src="{{ url }}" charset="utf-8"></script>
+<script{% if async %} async{% endif %}{% if defer %} defer{% endif %} type="{{ type }}" src="{{ url }}" charset="utf-8"{% if integrity %} integrity="{{ integrity }}"{% endif %}{% if crossorigin %} crossorigin="{{ crossorigin }}"{% endif %}></script>

--- a/pipeline/packager.py
+++ b/pipeline/packager.py
@@ -1,3 +1,7 @@
+import base64
+import hashlib
+from functools import lru_cache
+
 from django.contrib.staticfiles.finders import find, get_finders
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.core.files.base import ContentFile
@@ -60,6 +64,19 @@ class Package:
     @property
     def compiler_options(self):
         return self.config.get("compiler_options", {})
+
+    @lru_cache()
+    def get_sri(self, path):
+        method = self.config.get("integrity")
+        if method not in {"sha256", "sha384", "sha512"}:
+            return None
+        if staticfiles_storage.exists(path):
+            with staticfiles_storage.open(path) as fd:
+                h = getattr(hashlib, method)()
+                for data in iter(lambda: fd.read(16384), b""):
+                    h.update(data)
+            return "%s-%s" % (method, base64.b64encode(h.digest()).decode())
+        return None
 
 
 class Packager:

--- a/pipeline/packager.py
+++ b/pipeline/packager.py
@@ -65,7 +65,7 @@ class Package:
     def compiler_options(self):
         return self.config.get("compiler_options", {})
 
-    @lru_cache()
+    @lru_cache
     def get_sri(self, path):
         method = self.config.get("integrity")
         if method not in {"sha256", "sha384", "sha512"}:
@@ -75,7 +75,8 @@ class Package:
                 h = getattr(hashlib, method)()
                 for data in iter(lambda: fd.read(16384), b""):
                     h.update(data)
-            return "%s-%s" % (method, base64.b64encode(h.digest()).decode())
+            digest = base64.b64encode(h.digest()).decode()
+            return f"{method}-{digest}"
         return None
 
 

--- a/pipeline/templates/pipeline/js.html
+++ b/pipeline/templates/pipeline/js.html
@@ -1,1 +1,1 @@
-<script{% if async %} async{% endif %}{% if defer %} defer{% endif %} type="{{ type }}" src="{{ url }}" charset="utf-8"></script>
+<script{% if async %} async{% endif %}{% if defer %} defer{% endif %} type="{{ type }}" src="{{ url }}" charset="utf-8"{% if integrity %} integrity="{{ integrity }}"{% endif %}{% if crossorigin %} crossorigin="{{ crossorigin }}"{% endif %}></script>

--- a/pipeline/templates/pipeline/js.jinja
+++ b/pipeline/templates/pipeline/js.jinja
@@ -1,1 +1,1 @@
-<script{% if async %} async{% endif %}{% if defer %} defer{% endif %} type="{{ type }}" src="{{ url }}" charset="utf-8"></script>
+<script{% if async %} async{% endif %}{% if defer %} defer{% endif %} type="{{ type }}" src="{{ url }}" charset="utf-8"{% if integrity %} integrity="{{ integrity }}"{% endif %}{% if crossorigin %} crossorigin="{{ crossorigin }}"{% endif %}></script>

--- a/pipeline/templatetags/pipeline.py
+++ b/pipeline/templatetags/pipeline.py
@@ -180,6 +180,8 @@ class JavascriptNode(PipelineMixin, template.Node):
             {
                 "type": guess_type(path, "text/javascript"),
                 "url": mark_safe(staticfiles_storage.url(path)),
+                "crossorigin": package.config.get("crossorigin"),
+                "integrity": package.get_sri(path),
             }
         )
         return render_to_string(template_name, context)

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -137,6 +137,46 @@ PIPELINE = {
                 "defer": True,
             },
         },
+        "scripts_crossorigin": {
+            "source_filenames": (
+                "pipeline/js/first.js",
+                "pipeline/js/second.js",
+                "pipeline/js/application.js",
+                "pipeline/templates/**/*.jst",
+            ),
+            "output_filename": "scripts_crossorigin.js",
+            "crossorigin": "anonymous",
+        },
+        "scripts_sri_sha256": {
+            "source_filenames": (
+                "pipeline/js/first.js",
+                "pipeline/js/second.js",
+                "pipeline/js/application.js",
+                "pipeline/templates/**/*.jst",
+            ),
+            "output_filename": "scripts_sha256.js",
+            "integrity": "sha256",
+        },
+        "scripts_sri_sha384": {
+            "source_filenames": (
+                "pipeline/js/first.js",
+                "pipeline/js/second.js",
+                "pipeline/js/application.js",
+                "pipeline/templates/**/*.jst",
+            ),
+            "output_filename": "scripts_sha384.js",
+            "integrity": "sha384",
+        },
+        "scripts_sri_sha512": {
+            "source_filenames": (
+                "pipeline/js/first.js",
+                "pipeline/js/second.js",
+                "pipeline/js/application.js",
+                "pipeline/templates/**/*.jst",
+            ),
+            "output_filename": "scripts_sha512.js",
+            "integrity": "sha512",
+        },
     },
 }
 

--- a/tests/tests/test_template.py
+++ b/tests/tests/test_template.py
@@ -121,7 +121,8 @@ class JinjaTest(TestCase):
     def get_integrity(path, method):
         with staticfiles_storage.open(path) as fd:
             h = getattr(hashlib, method)(fd.read())
-        return "%s-%s" % (method, base64.b64encode(h.digest()).decode())
+        digest = base64.b64encode(h.digest()).decode()
+        return f"{method}-{digest}"
 
 
 class DjangoTest(TestCase):


### PR DESCRIPTION
Allow to integrate subresource-integrity attributes to <script tags>.
Require to add the two following keys beside "output_filename" in Django's setting PIPELINE['JAVASCRIPT']["your package"]:

    "crossorigin": "anonymous",
    "integrity": "sha384",

Of course, "sha256" and "sha512" also works.
Hashes are computed at runtime and cached to minimize code changes.

Cf. https://infosec.mozilla.org/guidelines/web_security#subresource-integrity