### PR TITLE
Replace deprecated .warn() method with .warning()

### DIFF
--- a/pipeline/templatetags/pipeline.py
+++ b/pipeline/templatetags/pipeline.py
@@ -132,7 +132,7 @@ class StylesheetNode(PipelineMixin, template.Node):
             package = self.package_for(package_name, "css")
         except PackageNotFound:
             w = "Package %r is unknown. Check PIPELINE['STYLESHEETS'] in your settings."
-            logger.warn(w, package_name)
+            logger.warning(w, package_name)
             # fail silently, do not return anything if an invalid group is specified
             return ""
         return self.render_compressed(package, package_name, "css")
@@ -168,7 +168,7 @@ class JavascriptNode(PipelineMixin, template.Node):
             package = self.package_for(package_name, "js")
         except PackageNotFound:
             w = "Package %r is unknown. Check PIPELINE['JAVASCRIPT'] in your settings."
-            logger.warn(w, package_name)
+            logger.warning(w, package_name)
             # fail silently, do not return anything if an invalid group is specified
             return ""
         return self.render_compressed(package, package_name, "js")


### PR DESCRIPTION
- `logging.Logger.warn()` has been deprecated since Python 3.3 and will not be available in Python 3.13 as per this pull request (https://github.com/python/cpython/pull/105377).