### PR TITLE
Ensure correct compiler error styling and strip ANSI escape sequences.

### DIFF
--- a/pipeline/templates/pipeline/compile_error.html
+++ b/pipeline/templates/pipeline/compile_error.html
@@ -1,5 +1,5 @@
 <div id="django-pipeline-error-{{package_name}}" class="django-pipeline-error"
-     style="display: none; border: 2px #DD0000 solid; margin: 1em; padding: 1em; background: white;">
+     style="display: none; border: 2px #DD0000 solid; margin: 1em; padding: 1em; background: white; color: black;">
  <h1>Error compiling {{package_type}} package "{{package_name}}"</h1>
  <p><strong>Command:</strong></p>
  <pre style="white-space: pre-wrap;">{{command}}</pre>

--- a/pipeline/templatetags/pipeline.py
+++ b/pipeline/templatetags/pipeline.py
@@ -114,7 +114,8 @@ class PipelineMixin:
         error_output = re.sub(
             re.compile(r"(?:\x1B[@-_]|[\x80-\x9F])[0-?]*[ -/]*[@-~]"),
             "",
-            e.error_output)
+            e.error_output,
+        )
 
         return render_to_string(
             "pipeline/compile_error.html",

--- a/pipeline/templatetags/pipeline.py
+++ b/pipeline/templatetags/pipeline.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import subprocess
 
 from django import template
@@ -109,13 +110,19 @@ class PipelineMixin:
         return method(package, paths, templates=templates)
 
     def render_error(self, package_type, package_name, e):
+        # Remove any ANSI escape sequences in the output.
+        error_output = re.sub(
+            re.compile(r"(?:\x1B[@-_]|[\x80-\x9F])[0-?]*[ -/]*[@-~]"),
+            "",
+            e.error_output)
+
         return render_to_string(
             "pipeline/compile_error.html",
             {
                 "package_type": package_type,
                 "package_name": package_name,
                 "command": subprocess.list2cmdline(e.command),
-                "errors": e.error_output,
+                "errors": error_output,
             },
         )
 


### PR DESCRIPTION
The compiler error output that's injected into the page hard-codes a background color of white, but didn't hard-code a corresponding text color. If the page had set a default text color that was too close to white, it would be hard or impossible to read without selecting the text on the page.

This change addresses this by hard-coding a text color of black, ensuring it can be read.

It also goes a step further and improves the display when dealing with ANSI escape sequences in the error output, making it difficult to read through or copy/paste meaningful results. We now apply a common regex for stripping away any typical ANSI escape sequences we should expect in such output, leaving behind only the plain text content.


# Testing

Triggered a compilation error on a page that had a default text color of white, with a compiler that had many ANSI escape sequences present (rollup.js). I verified that I could now read the text and without the distraction of the escape sequences.

Ran `tox`. Unit tests pass.