### PR TITLE
Specify packages using include rather than exclude

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ changelog = "https://github.com/jazzband/django-pipeline/blob/master/HISTORY.rst
 include-package-data = true
 
 [tool.setuptools.packages.find]
-exclude = ["tests", "tests.tests"]
+exclude = ["tests", "tests.*"]
 
 [tool.setuptools_scm]
 local_scheme = "dirty-tag"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ changelog = "https://github.com/jazzband/django-pipeline/blob/master/HISTORY.rst
 include-package-data = true
 
 [tool.setuptools.packages.find]
-exclude = ["tests", "tests.*"]
+include = ["pipeline", "pipeline.*"]
 
 [tool.setuptools_scm]
 local_scheme = "dirty-tag"


### PR DESCRIPTION
A built wheel of this package includes a number of files under `tests/assets/` and `tests/templates/`, which is namespace pollution and doesn't seem to be intentional.  Remove them.

Specifying packages using `include` rather than `exclude` avoids possible duplication if a wheel is built more than once from the same directory.  It also avoids files from the `docs` and `img` directories ending up in the wheel, which doesn't seem desirable.