### PR TITLE
Remove dead pkg_resources fallback

### DIFF
--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -1,28 +1,6 @@
-PackageNotFoundError = None
-DistributionNotFound = None
+from importlib.metadata import PackageNotFoundError, version
+
 try:
-    from importlib.metadata import PackageNotFoundError
-    from importlib.metadata import version as get_version
-except ImportError:
-    get_version = None
-    PackageNotFoundError = None
-if get_version is None:
-    try:
-        from pkg_resources import DistributionNotFound, get_distribution
-
-        def get_version(x):
-            return get_distribution(x).version
-
-    except ImportError:
-        get_version = None
-        DistributionNotFound = None
-        get_distribution = None
-
-__version__ = None
-if get_version is not None:
-    try:
-        __version__ = get_version("django-pipeline")
-    except PackageNotFoundError:
-        pass
-    except DistributionNotFound:
-        pass
+    __version__ = version("django-pipeline")
+except PackageNotFoundError:
+    __version__ = None


### PR DESCRIPTION
## Summary

Simplify `pipeline/__init__.py` by removing the dead `pkg_resources` fallback chain.

## Problem

The file had 24 lines of complex fallback logic:
```python
PackageNotFoundError = None
DistributionNotFound = None
try:
    from importlib.metadata import PackageNotFoundError
    from importlib.metadata import version as get_version
except ImportError:
    get_version = None
    PackageNotFoundError = None
if get_version is None:
    try:
        from pkg_resources import DistributionNotFound, get_distribution
        def get_version(x):
            return get_distribution(x).version
    except ImportError:
        get_version = None
        DistributionNotFound = None
        get_distribution = None

__version__ = None
if get_version is not None:
    try:
        __version__ = get_version("django-pipeline")
    except PackageNotFoundError:
        pass
    except DistributionNotFound:
        pass
```

Since **django-pipeline requires Python >=3.9** (per `pyproject.toml`), `importlib.metadata` is **always available**. The entire `pkg_resources` fallback and `ImportError` handling is dead code.

## Fix

Replace with 5 lines:
```python
from importlib.metadata import PackageNotFoundError, version

try:
    __version__ = version("django-pipeline")
except PackageNotFoundError:
    __version__ = None
```

- 19 lines of dead code removed
- Uses stdlib `importlib.metadata` directly (no fallbacks needed)
- Same behavior for Python 3.9+