### PR TITLE
docs: update documentation to use STORAGES for Django 4.2+

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -15,9 +15,22 @@ Installation
            'pipeline',
        )
 
-3. Use a pipeline storage for ``STATICFILES_STORAGE`` ::
+3. Use a pipeline storage for static files.
+
+   **For Django < 4.2:**
 
         STATICFILES_STORAGE = 'pipeline.storage.PipelineManifestStorage'
+
+   **For Django >= 4.2:**
+
+        STORAGES = {
+            'default': {
+                'BACKEND': 'django.core.files.storage.FileSystemStorage',
+            },
+            'staticfiles': {
+                'BACKEND': 'pipeline.storage.PipelineManifestStorage',
+            },
+        }
 
 4. Add the ``PipelineFinder`` to ``STATICFILES_FINDERS`` ::
 

--- a/docs/storages.rst
+++ b/docs/storages.rst
@@ -8,8 +8,16 @@ Storages
 Using with staticfiles
 ======================
 
-Pipeline is providing a storage for `staticfiles app <https://docs.djangoproject.com/en/dev/howto/static-files/>`_,
-to use it configure ``STATICFILES_STORAGE`` like so ::
+Pipeline is providing a storage for `staticfiles app <https://docs.djangoproject.com/en/dev/howto/static-files/>`_.
+
+.. note::
+
+   ``STATICFILES_STORAGE`` is deprecated in Django 4.2 and removed in Django 5.1.
+   For Django 4.2+, use the ``STORAGES`` setting instead.
+
+**For Django < 4.2:**
+
+Configure ``STATICFILES_STORAGE`` like so ::
 
   STATICFILES_STORAGE = 'pipeline.storage.PipelineStorage'
 
@@ -25,6 +33,53 @@ without packaging your assets. Useful for production when you don't want to run 
 Also available if you want versioning ::
 
   STATICFILES_STORAGE = 'pipeline.storage.NonPackagingPipelineManifestStorage'
+
+**For Django >= 4.2:**
+
+Configure ``STORAGES`` like so ::
+
+  STORAGES = {
+      'default': {
+          'BACKEND': 'django.core.files.storage.FileSystemStorage',
+      },
+      'staticfiles': {
+          'BACKEND': 'pipeline.storage.PipelineStorage',
+      },
+  }
+
+And if you want versioning use ::
+
+  STORAGES = {
+      'default': {
+          'BACKEND': 'django.core.files.storage.FileSystemStorage',
+      },
+      'staticfiles': {
+          'BACKEND': 'pipeline.storage.PipelineManifestStorage',
+      },
+  }
+
+There is also non-packing storage available, that allows you to run ``collectstatic`` command
+without packaging your assets. Useful for production when you don't want to run compressor or compilers ::
+
+  STORAGES = {
+      'default': {
+          'BACKEND': 'django.core.files.storage.FileSystemStorage',
+      },
+      'staticfiles': {
+          'BACKEND': 'pipeline.storage.NonPackagingPipelineStorage',
+      },
+  }
+
+Also available if you want versioning ::
+
+  STORAGES = {
+      'default': {
+          'BACKEND': 'django.core.files.storage.FileSystemStorage',
+      },
+      'staticfiles': {
+          'BACKEND': 'pipeline.storage.NonPackagingPipelineManifestStorage',
+      },
+  }
 
 If you use staticfiles with ``DEBUG = False`` (i.e. for integration tests
 with `Selenium <http://docs.seleniumhq.org/>`_) you should install the finder

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -86,9 +86,27 @@ Example
 Collect static
 ==============
 
-Pipeline integrates with staticfiles, you just need to setup ``STATICFILES_STORAGE`` to ::
+Pipeline integrates with staticfiles, you just need to configure the static files storage.
+
+.. note::
+
+   ``STATICFILES_STORAGE`` is deprecated in Django 4.2 and removed in Django 5.1.
+   For Django 4.2+, use the ``STORAGES`` setting instead.
+
+**For Django < 4.2:**
 
     STATICFILES_STORAGE = 'pipeline.storage.PipelineStorage'
+
+**For Django >= 4.2:**
+
+    STORAGES = {
+        'default': {
+            'BACKEND': 'django.core.files.storage.FileSystemStorage',
+        },
+        'staticfiles': {
+            'BACKEND': 'pipeline.storage.PipelineStorage',
+        },
+    }
 
 Then when you run ``collectstatic`` command, your CSS and your javascripts will be compressed at the same time ::
 
@@ -98,9 +116,22 @@ Cache-busting
 -------------
 
 Pipeline 1.2+ no longer provides its own cache-busting URL support (using e.g. the ``PIPELINE_VERSIONING`` setting) but uses
-Django's built-in staticfiles support for this. To set up cache-busting in conjunction with ``collectstatic`` as above, use ::
+Django's built-in staticfiles support for this. To set up cache-busting in conjunction with ``collectstatic`` as above, use:
+
+**For Django < 4.2:**
 
     STATICFILES_STORAGE = 'pipeline.storage.PipelineCachedStorage'
+
+**For Django >= 4.2:**
+
+    STORAGES = {
+        'default': {
+            'BACKEND': 'django.core.files.storage.FileSystemStorage',
+        },
+        'staticfiles': {
+            'BACKEND': 'pipeline.storage.PipelineCachedStorage',
+        },
+    }
 
 This will handle cache-busting just as ``staticfiles``'s built-in ``CachedStaticFilesStorage`` does.
 


### PR DESCRIPTION
## Summary

Fixes #831.

Update documentation to show both the deprecated `STATICFILES_STORAGE` setting for Django < 4.2 and the new `STORAGES` setting for Django >= 4.2.

## Changes

- Updated `docs/storages.rst` to include both old and new settings
- Updated `docs/installation.rst` to include both old and new settings
- Updated `docs/usage.rst` to include both old and new settings
- Added notes about the deprecation of `STATICFILES_STORAGE` in Django 4.2

## Background

The `STATICFILES_STORAGE` setting is deprecated in Django 4.2 and removed in Django 5.1. Users need to use `STORAGES` for newer Django versions. This documentation update helps users understand how to configure Pipeline for both old and new Django versions.

## Test evidence

The documentation builds successfully:

```
cd docs && make html
```

All existing tests pass.